### PR TITLE
Fix the cron job.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -22,6 +22,11 @@ handlers:
   login: required
   secure: always
 
+- url: /cron/proxyserver/distributekey
+  script: proxy_server.app
+  login: admin
+  secure: always
+
 - url: /setup.*
   script: setup.app
   login: required

--- a/cron.yaml
+++ b/cron.yaml
@@ -3,5 +3,5 @@ cron:
 # logic to avoid running if user info has not changed since last run would be
 # beneficial.
 - description: Distribute keys to proxy servers.
-  url: /key/distribute
+  url: /cron/proxyserver/distributekey
   schedule: every 15 minutes

--- a/proxy_server.py
+++ b/proxy_server.py
@@ -111,6 +111,7 @@ class ListProxyServersHandler(webapp2.RequestHandler):
 
 class DistributeKeyHandler(webapp2.RequestHandler):
 
+  # This handler requires admin login, and is controlled in the app.yaml.
   def get(self):
     # TODO(henry): See if we can use threading to parallelize the put requests.
     key_string = _MakeKeyString()

--- a/proxy_server.py
+++ b/proxy_server.py
@@ -111,10 +111,6 @@ class ListProxyServersHandler(webapp2.RequestHandler):
 
 class DistributeKeyHandler(webapp2.RequestHandler):
 
-  # This is accessed by the cron service, which only has appengine admin access.
-  # So if the admin check changes here, we might have to move this to a
-  # different module.
-  @admin.require_admin
   def get(self):
     # TODO(henry): See if we can use threading to parallelize the put requests.
     key_string = _MakeKeyString()
@@ -138,7 +134,8 @@ class DistributeKeyHandler(webapp2.RequestHandler):
 app = webapp2.WSGIApplication([
     ('/proxyserver/add', AddProxyServerHandler),
     ('/proxyserver/delete', DeleteProxyServerHandler),
-    ('/proxyserver/distributekey', DistributeKeyHandler),
     ('/proxyserver/edit', EditProxyServerHandler),
     ('/proxyserver/list', ListProxyServersHandler),
+
+    ('/cron/proxyserver/distributekey', DistributeKeyHandler),
 ], debug=True)

--- a/proxy_server_test.py
+++ b/proxy_server_test.py
@@ -103,7 +103,7 @@ class ProxyServerTest(unittest.TestCase):
     fake_key_string = 'ssh-rsa public_key email'
     mock_make_key_string.return_value = fake_key_string
 
-    self.testapp.get('/proxyserver/distributekey')
+    self.testapp.get('/cron/proxyserver/distributekey')
     mock_request.assert_called_once_with(
         'http://%s/key' % fake_proxy_server.ip_address,
         headers={'content-type': 'text/plain'},


### PR DESCRIPTION
There are a couple of problems here:
1) the cron job was hitting the wrong handler
2) the target handler can not require user sign-in

I tried several ways to fix #2 as cleanly as possible, but appengine regex engine doesn't support negative lookahead.  So the next easiest way is to break out the cron handler into a separate "/cron" path and assign the admin login.

We may move to use appengine tasks later but for now, this PR fixes things as they are.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server/33)
<!-- Reviewable:end -->
