### PR TITLE
Fix a Bunch of Lint Errors

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -7,7 +7,15 @@ from google.appengine.api import users
 
 def require_admin(func):
   """Decorator to require the user to be an admin."""
+
   def decorate(self, *args, **kwargs):
+    """Actual decorate function that requires admin.
+
+    Args:
+      args: Parameters passed on to the specified function if successful.
+      kwargs: Parameters passed on to the specified function if successful.
+    """
+
     user = users.get_current_user()
     if not user:
       logging.error('user is not logged in')

--- a/datastore.py
+++ b/datastore.py
@@ -318,6 +318,15 @@ class DomainVerification(BaseModel):
 
   @staticmethod
   def GetOrInsertDefault():
+    """Get the DomainVerification entity from the datastore.
+
+    If no entity exists in the datastore currently, this inserts an entity with
+    default values and returns that.
+
+    Returns:
+      The datastore entity for DomainVerification.
+    """
+
     entity = DomainVerification.Get(DomainVerification.CONTENT_ID)
     if not entity:
       DomainVerification.InsertDefault()
@@ -326,16 +335,34 @@ class DomainVerification(BaseModel):
 
   @staticmethod
   def InsertDefault():
+    """Insert the DV entity with default content into the datastore.
+    """
+
     DomainVerification.Insert(DomainVerification.DEFAULT_CONTENT)
 
   @staticmethod
   def Insert(new_content):
+    """Insert an entity with the new content into the datastore.
+
+    By inserting with the set id, we ensure never to generate multiple DV
+    entities.
+
+    Args:
+      new_content: The content value to set on the DomainVerification entity.
+    """
+
     entity = DomainVerification(id=DomainVerification.CONTENT_ID,
                                 content=new_content)
     entity.put()
 
   @staticmethod
   def Update(new_content):
+    """Update the DomainVerification entity with the new content.
+
+    Args:
+      new_content: The content value to set on the DomainVerification entity.
+    """
+
     entity = DomainVerification.Get(DomainVerification.CONTENT_ID)
     entity.content = new_content
     entity.put()

--- a/datastore.py
+++ b/datastore.py
@@ -241,14 +241,14 @@ class OAuth(BaseModel):
   # object it is used to get has a parameter which is the actual secret. This
   # however is not.
   CLIENT_SECRET_ID = 'my_client_secret'  # noqa
-
-  client_id = ndb.StringProperty()
-  client_secret = ndb.StringProperty()
   DEFAULT_ID = 'Change me to the real id.'
   # The comment below disables landscape.io checking on that line so that it
   # does not think we have an actual secret stored which we do not. This is a
   # default value to use in place of a real secret in the datastore.
   DEFAULT_SECRET = 'Change me to the real secret.'  # noqa
+
+  client_id = ndb.StringProperty()
+  client_secret = ndb.StringProperty()
 
   @staticmethod
   def GetOrInsertDefault():
@@ -269,8 +269,7 @@ class OAuth(BaseModel):
 
   @staticmethod
   def InsertDefault():
-    """Insert an entity with default client id and secret into the datastore.
-    """
+    """Insert entity with default client id and secret into the datastore."""
 
     OAuth.Insert(new_client_id=OAuth.DEFAULT_ID,
                  new_client_secret=OAuth.DEFAULT_SECRET)
@@ -342,8 +341,7 @@ class DomainVerification(BaseModel):
 
   @staticmethod
   def InsertDefault():
-    """Insert the DV entity with default content into the datastore.
-    """
+    """Insert the DV entity with default content into the datastore."""
 
     DomainVerification.Insert(DomainVerification.DEFAULT_CONTENT)
 

--- a/datastore.py
+++ b/datastore.py
@@ -236,12 +236,19 @@ class OAuth(BaseModel):
   https://console.developers.google.com/project
   Set the secret using the Datastore Viewer at https://appengine.google.com
   """
-  CLIENT_SECRET_ID = 'my_client_secret'
+  # The comment below disables landscape.io checking on that line so that it
+  # does not think we have an actual secret stored which we do not. The
+  # object it is used to get has a parameter which is the actual secret. This
+  # however is not.
+  CLIENT_SECRET_ID = 'my_client_secret'  # noqa
 
   client_id = ndb.StringProperty()
   client_secret = ndb.StringProperty()
   DEFAULT_ID = 'Change me to the real id.'
-  DEFAULT_SECRET = 'Change me to the real secret.'
+  # The comment below disables landscape.io checking on that line so that it
+  # does not think we have an actual secret stored which we do not. This is a
+  # default value to use in place of a real secret in the datastore.
+  DEFAULT_SECRET = 'Change me to the real secret.'  # noqa
 
   @staticmethod
   def GetOrInsertDefault():

--- a/error_handlers.py
+++ b/error_handlers.py
@@ -7,6 +7,14 @@ from oauth2client.client import FlowExchangeError
 
 # pylint: disable=unused-argument
 def Handle500(request, response, exception):
+  """Handle status 500 http request errors generically.
+
+  Args:
+    request: The request that generated a status 500.
+    response: The response object to write to or redirect on.
+    exception: The specific exception caused by the request.
+  """
+
   if (isinstance(exception, FlowExchangeError)
       and exception.message == 'invalid_client'):
     response.write('Setup your client_secret in the datastore.')

--- a/logout.py
+++ b/logout.py
@@ -10,7 +10,7 @@ class LogoutHandler(webapp2.RequestHandler):
   """Logs the current user out."""
 
   def get(self):
-	  """Log the user out and point the login address to the default path."""
+    """Log the user out and point the login address to the default path."""
 
     logout_url = users.create_logout_url(LOG_BACK_IN_PATH)
     self.redirect(logout_url)

--- a/logout.py
+++ b/logout.py
@@ -8,6 +8,7 @@ LOG_BACK_IN_PATH = '/user'
 
 class LogoutHandler(webapp2.RequestHandler):
   """Logs the current user out."""
+	# pylint: disable=too-few-public-methods
 
   def get(self):
     """Log the user out and point the login address to the default path."""

--- a/logout.py
+++ b/logout.py
@@ -10,6 +10,8 @@ class LogoutHandler(webapp2.RequestHandler):
   """Logs the current user out."""
 
   def get(self):
+	  """Log the user out and point the login address to the default path."""
+
     logout_url = users.create_logout_url(LOG_BACK_IN_PATH)
     self.redirect(logout_url)
 

--- a/proxy_server.py
+++ b/proxy_server.py
@@ -52,7 +52,7 @@ def _MakeKeyString():
   endline = '\n'
   for user in users:
     user_string = (ssh_starting_portion + space + user.public_key + space +
-                  user.email + endline)
+                   user.email + endline)
     key_string += user_string
 
   return key_string

--- a/proxy_server.py
+++ b/proxy_server.py
@@ -59,14 +59,18 @@ def _MakeKeyString():
 
 
 class AddProxyServerHandler(webapp2.RequestHandler):
+  """Handler for adding new proxy servers."""
 
   @admin.require_admin
   def get(self):
+    """Get the form for adding new proxy servers."""
+
     self.response.write(_RenderProxyServerFormTemplate(None))
 
   @admin.require_admin
   @xsrf.xsrf_protect
   def post(self):
+    """Add a new proxy server with the post parameters passed in."""
     ProxyServer.Insert(
         self.request.get('name'),
         self.request.get('ip_address'),
@@ -76,15 +80,18 @@ class AddProxyServerHandler(webapp2.RequestHandler):
 
 
 class EditProxyServerHandler(webapp2.RequestHandler):
+  """Handler for editing an existing proxy server."""
 
   @admin.require_admin
   def get(self):
+    """Get a proxy server's current data and display its edit form."""
     proxy_server = ProxyServer.Get(int(self.request.get('id')))
     self.response.write(_RenderProxyServerFormTemplate(proxy_server))
 
   @admin.require_admin
   @xsrf.xsrf_protect
   def post(self):
+    """Set an existing proxy server with the post parameters passed in."""
     ProxyServer.Update(
         int(self.request.get('id')),
         self.request.get('name'),
@@ -95,24 +102,37 @@ class EditProxyServerHandler(webapp2.RequestHandler):
 
 
 class DeleteProxyServerHandler(webapp2.RequestHandler):
+  """Handler for deleting an existing proxy server."""
 
   @admin.require_admin
   def get(self):
+    """Delete the proxy server corresponding to the passed in id.
+
+    If we had access to a delete method then we would not use get here.
+    """
     ProxyServer.Delete(int(self.request.get('id')))
     self.response.write(_RenderListProxyServerTemplate())
 
 
 class ListProxyServersHandler(webapp2.RequestHandler):
+  """Handler for listing all existing proxy servers."""
 
   @admin.require_admin
   def get(self):
+    """Get all current proxy servers and list them with their metadata."""
     self.response.write(_RenderListProxyServerTemplate())
 
 
 class DistributeKeyHandler(webapp2.RequestHandler):
+  """Handler for distributing authorization keys out to each proxy server."""
 
   # This handler requires admin login, and is controlled in the app.yaml.
   def get(self):
+    """Send the current users and associated key out to each proxy server.
+
+    This handler is not intended primarily for a typical user, but for a cron
+    job to periodically trigger.
+    """
     # TODO(henry): See if we can use threading to parallelize the put requests.
     key_string = _MakeKeyString()
     proxy_servers = ProxyServer.GetAll()

--- a/proxy_server.py
+++ b/proxy_server.py
@@ -117,6 +117,7 @@ class DeleteProxyServerHandler(webapp2.RequestHandler):
 
 class ListProxyServersHandler(webapp2.RequestHandler):
   """Handler for listing all existing proxy servers."""
+  # pylint: disable=too-few-public-methods
 
   @admin.require_admin
   def get(self):
@@ -126,6 +127,7 @@ class ListProxyServersHandler(webapp2.RequestHandler):
 
 class DistributeKeyHandler(webapp2.RequestHandler):
   """Handler for distributing authorization keys out to each proxy server."""
+  # pylint: disable=too-few-public-methods
 
   # This handler requires admin login, and is controlled in the app.yaml.
   def get(self):

--- a/proxy_server.py
+++ b/proxy_server.py
@@ -103,6 +103,7 @@ class EditProxyServerHandler(webapp2.RequestHandler):
 
 class DeleteProxyServerHandler(webapp2.RequestHandler):
   """Handler for deleting an existing proxy server."""
+  # pylint: disable=too-few-public-methods
 
   @admin.require_admin
   def get(self):

--- a/user.py
+++ b/user.py
@@ -179,6 +179,7 @@ class LandingPageHandler(webapp2.RequestHandler):
 
 class ListUsersHandler(webapp2.RequestHandler):
   """List the current users."""
+  # pylint: disable=too-few-public-methods
 
   @OAUTH_DECORATOR.oauth_required
   def get(self):
@@ -188,6 +189,7 @@ class ListUsersHandler(webapp2.RequestHandler):
 
 class DeleteUserHandler(webapp2.RequestHandler):
   """Delete a given user."""
+  # pylint: disable=too-few-public-methods
 
   @OAUTH_DECORATOR.oauth_required
   def get(self):
@@ -202,6 +204,7 @@ class DeleteUserHandler(webapp2.RequestHandler):
 
 class ListTokensHandler(webapp2.RequestHandler):
   """List the tokens and associated users."""
+  # pylint: disable=too-few-public-methods
 
   @OAUTH_DECORATOR.oauth_required
   def get(self):
@@ -211,6 +214,7 @@ class ListTokensHandler(webapp2.RequestHandler):
 
 class GetInviteCodeHandler(webapp2.RequestHandler):
   """Get an invite code for a given user."""
+  # pylint: disable=too-few-public-methods
 
   @OAUTH_DECORATOR.oauth_required
   def get(self):
@@ -224,6 +228,7 @@ class GetInviteCodeHandler(webapp2.RequestHandler):
 
 class GetNewTokenHandler(webapp2.RequestHandler):
   """Create a new token for a given user."""
+  # pylint: disable=too-few-public-methods
 
   @OAUTH_DECORATOR.oauth_required
   def get(self):

--- a/user.py
+++ b/user.py
@@ -170,6 +170,7 @@ def _RenderAddUsersTemplate(directory_users):
 
 class LandingPageHandler(webapp2.RequestHandler):
   """Display the landing page which doesn't require oauth."""
+  # pylint: disable=too-few-public-methods
 
   def get(self):
     """Output the landing page template."""

--- a/user.py
+++ b/user.py
@@ -169,38 +169,51 @@ def _RenderAddUsersTemplate(directory_users):
 
 
 class LandingPageHandler(webapp2.RequestHandler):
+  """Display the landing page which doesn't require oauth."""
 
   def get(self):
+    """Output the landing page template."""
     self.response.write(_RenderLandingTemplate())
 
 
 class ListUsersHandler(webapp2.RequestHandler):
+  """List the current users."""
 
   @OAUTH_DECORATOR.oauth_required
   def get(self):
+    """Output a list of all current users along with some metadata."""
     self.response.write(_RenderUserListTemplate())
 
 
 class DeleteUserHandler(webapp2.RequestHandler):
+  """Delete a given user."""
 
   @OAUTH_DECORATOR.oauth_required
   def get(self):
+    """Delete the user corresponding to the passed in key.
+
+    If we had access to a delete method then we would not use get here.
+    """
     urlsafe_key = self.request.get('key')
     User.DeleteByKey(urlsafe_key)
     self.response.write(_RenderUserListTemplate())
 
 
 class ListTokensHandler(webapp2.RequestHandler):
+  """List the tokens and associated users."""
 
   @OAUTH_DECORATOR.oauth_required
   def get(self):
+    """Output a list of all current users along with each's token."""
     self.response.write(_RenderTokenListTemplate())
 
 
 class GetInviteCodeHandler(webapp2.RequestHandler):
+  """Get an invite code for a given user."""
 
   @OAUTH_DECORATOR.oauth_required
   def get(self):
+    """Output a list of all current users along with the requested token."""
     urlsafe_key = self.request.get('key')
     user = User.GetByKey(urlsafe_key)
     invite_code = _MakeInviteCode(user)
@@ -209,9 +222,11 @@ class GetInviteCodeHandler(webapp2.RequestHandler):
 
 
 class GetNewTokenHandler(webapp2.RequestHandler):
+  """Create a new token for a given user."""
 
   @OAUTH_DECORATOR.oauth_required
   def get(self):
+    """Find the user matching the specified key and generate a new token."""
     urlsafe_key = self.request.get('key')
     User.UpdateKeyPair(urlsafe_key)
 
@@ -224,6 +239,14 @@ class AddUsersHandler(webapp2.RequestHandler):
   @admin.require_admin
   @OAUTH_DECORATOR.oauth_required
   def get(self):
+    """Get the form for adding new users.
+
+    If get_all is passed in, all users in the domain will be listed to select.
+    If a group_key is passed in and that group is found, all users in that
+    group will be listed to select. We do not list groups within groups though.
+    If neither is passed in, the form is still displayed without any users
+    listed.
+    """
     get_all = self.request.get('get_all')
     group_key = self.request.get('group_key')
     if get_all:
@@ -245,6 +268,7 @@ class AddUsersHandler(webapp2.RequestHandler):
   @xsrf.xsrf_protect
   @OAUTH_DECORATOR.oauth_required
   def post(self):
+    """Add all of the selected users into the datastore."""
     params = self.request.get_all('selected_user')
     users = []
     for param in params:

--- a/xsrf.py
+++ b/xsrf.py
@@ -17,6 +17,7 @@ from google.appengine.ext import ndb
 
 
 def xsrf_token():
+  """Generate a new xsrf secret and output it in urlsafe base64 encoding."""
   digester = hmac.new(str(XsrfSecret.get()))
   digester.update(str(users.get_current_user().user_id()))
   return base64.urlsafe_b64encode(digester.digest())
@@ -25,6 +26,12 @@ def xsrf_token():
 def xsrf_protect(func):
   """Decorator to require valid XSRF token."""
   def decorate(self, *args, **kwargs):
+    """Actual decorate function that requires a valid XSRF token.
+
+    Args:
+      args: Parameters passed on to the specified function if successful.
+      kwargs: Parameters passed on to the specified function if successful.
+    """
     token = self.request.get('xsrf', None)
     if not token:
       logging.error('xsrf token not included')

--- a/xsrf.py
+++ b/xsrf.py
@@ -58,6 +58,7 @@ def const_time_compare(a, b):
 
 class XsrfSecret(ndb.Model):
   """Model for datastore to store the XSRF secret."""
+  # pylint: disable=too-few-public-methods
   secret = ndb.StringProperty(required=True)
 
   @staticmethod


### PR DESCRIPTION
This pull does not functionally change anything. It only adds numerous fixes for code health, such as adding many docstrings, fixing line continuation, removing checks for too few public methods on several get handlers, and adding an exception for the dodgy tool thinking we are storing a hardcoded secret.

We of course are not storing a hardcoded secret. However, the name of the parameter is literally called a "client secret" so dodgy's regex parsing picks that up as a possible problem. There's no way to name something secret without naming it secret or using some abbreviation, so I've simply turned off that check to stop it from failing on us.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server/34)
<!-- Reviewable:end -->
