### PR TITLE
Add Clean and Bower Support to Setup Script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.7"
 # command to setup environment and install dependencies
 install:
- - ./setup.sh setup_tests
+ - ./setup.sh travis
 before_script:
  - source .bash_profile
 # command to run tests

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ modify (`/usr/local`) to being editable by your user (`sudo chown -R $USER /usr/
 
  1. Navigate into UfO's root directory with `cd ufo-management-server`
 
- 1. Setup build tools and third-party dependencies, run `./setup.sh setup_tests`
+ 1. Setup build tools and third-party dependencies, run `./setup.sh setup`
 
 #### Setup with Setup.sh
 
@@ -59,16 +59,12 @@ modify (`/usr/local`) to being editable by your user (`sudo chown -R $USER /usr/
 
  1. Run `./setup.sh install`
 
-#### Installing Client-Side Components
-
-Currently, the setup script does not account for installing client-side components through bower. Later versions will support this, but it is not yet implemented.
-
- 1. Install bower, with node this is simply `npm install bower`.
- 1. Run `bower install` to get the client-side components.
-
 #### Note About Dependency Changes
 
-Note that if any local dependencies have changed (i.e. changes to bower dependencies, updates to pip packages), you will have to remove your appengine directory and run `./setup.sh setup_tests` to update these dependencies.
+Note that if any local dependencies have changed (i.e. changes to bower dependencies, updates to pip packages, releases of appengine), you will have to add the new dependency manually or reset completely with the script. To reset with the script, perform the following:
+
+ 1. Run `sudo ./setup.sh clean`
+ 1. Run `./setup.sh setup`
 
 ### Setting Up OAuth
 
@@ -99,9 +95,8 @@ As part of the OAuth flow, the server must present a “secret” in order to pr
 
 Our tests run on [Travis](https://travis-ci.org/) for every commit, push, and pull request automatically. To execute the tests locally before commit, perform the following:
 
- 1. Ensure your environment is configured properly. Run `./setup.sh setup_tests` if not.
+ 1. Ensure your environment is configured properly. Run `./setup.sh setup` if not.
  1. Execute the tests with your modified code.
-   * Run `./setup.sh run_tests` or
    * Run `python -m unittest discover -p "*_test.py"`
 
 ### Running the Server
@@ -110,7 +105,7 @@ Our tests run on [Travis](https://travis-ci.org/) for every commit, push, and pu
 
 Once you have the source code and dependencies in your environment, running the code on your local machine should be very straightforward.
 
- 1. Ensure your environment is configured properly. Run `./setup.sh setup_tests` if not.
+ 1. Ensure your environment is configured properly. Run `./setup.sh setup` if not.
  1. Deploy the server locally:
    * Run `<path_to_appengine_sdk>/dev_appserver.py --port=9999 .` Note the trailing period is required.
    * This is typically `../google_appengine/dev_appserver.py --port=9999 .`
@@ -119,7 +114,7 @@ Once you have the source code and dependencies in your environment, running the 
 
 #### Deploying Cloud Server (Appspot)
 
- 1. Ensure your environment is configured properly. Run `./setup.sh setup_tests` if not.
+ 1. Ensure your environment is configured properly. Run `./setup.sh setup` if not.
  1. Deploy the server to the cloud:
    * Deploy directly:
      * Run `<path_to_appengine_sdk>/appcfg.py -A <your-project-name-here> update .` Note the trailing period is required.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Management Server component of uProxy for Orgs (UfO)
 ## Status
 
 [![Travis Status](https://travis-ci.org/uProxy/ufo-management-server.svg)](https://travis-ci.org/uProxy/ufo-management-server)
-[![Code Health](https://landscape.io/github/uProxy/ufo-management-server/landscape/landscape.svg?style=flat)](https://landscape.io/github/uProxy/ufo-management-server/landscape)
+[![Code Health](https://landscape.io/github/uProxy/ufo-management-server/master/landscape.svg?style=flat)](https://landscape.io/github/uProxy/ufo-management-server/master)
 
 ## Tools
 

--- a/setup.sh
+++ b/setup.sh
@@ -56,6 +56,7 @@ function runAndAssertCmd ()
     # code.
     set -e && cd $ROOT_DIR && eval $1
 }
+
 function runInUfOAndAssertCmd ()
 {
     echo "Running: $1"
@@ -273,6 +274,41 @@ function printHelp ()
   echo
 }
 
+function bareMetalInstall ()
+{
+  # Using variables here to make things fit on 80 character lines.
+  PYTHON_DEPS1="libreadline-gplv2-dev libncursesw5-dev libssl-dev"
+  PYTHON_DEPS2="libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev"
+  PYTHON_NAME="Python-2.7.9"
+  PYTHON_TGZ="wget https://www.python.org/ftp/python/2.7.9/${PYTHON_NAME}.tgz"
+  PYTHON_EXTRACT="tar -xvf ${PYTHON_NAME}.tgz"
+
+  echo "If this fails, consider retrying with sudo pre-fixed."
+
+  echo "Step 1/4: Installing Python"
+  runAndAssertCmd "apt-get install build-essential"
+  runAndAssertCmd "apt-get install $PYTHON_DEPS1 $PYTHON_DEPS2"
+  set -e && cd ~/Downloads/ && eval $PYTHON_TGZ
+  set -e && cd ~/Downloads/ && eval $PYTHON_EXTRACT
+  set -e && cd $PYTHON_NAME && eval "./configure"
+  set -e && cd $PYTHON_NAME && eval "make"
+  set -e && cd $PYTHON_NAME && eval "make install"
+
+  echo "Step 2/4: Installing Pip"
+  runAndAssertCmd "apt-get install python-pip"
+
+  echo "Step 3/4: Installing Git"
+  runAndAssertCmd "apt-get install git-all"
+
+  # I probably need to have another step in here for setting environment vars
+  # correctly so that python, pip, and git can be run correctly. I can't test
+  # this currently though, so I'm assuming it works and will iterate on it
+  # later if necessary.
+
+  echo "Step 4/4: Installing Management Server"
+  installManagementServer
+}
+
 if [ "$1" == 'install' ]; then
   installManagementServer
 elif [ "$1" == 'release' ]; then
@@ -285,6 +321,8 @@ elif [ "$1" == 'setup' ]; then
   setupDevelopmentEnvironment
 elif [ "$1" == 'clean' ]; then
   clean
+elif [ "$1" == 'metal' ]; then
+  bareMetalInstall
 else
   printHelp
   exit 0

--- a/setup.sh
+++ b/setup.sh
@@ -56,6 +56,14 @@ function runAndAssertCmd ()
     # code.
     set -e && cd $ROOT_DIR && eval $1
 }
+function runInUfOAndAssertCmd ()
+{
+    echo "Running: $1"
+    echo
+    # We use set -e to make sure this will fail if the command returns an error
+    # code.
+    set -e && cd $UFO_MS_LOCAL_DIR && eval $1
+}
 
 function setupAppEngine ()
 {
@@ -103,7 +111,7 @@ function addBower ()
   runAndAssertCmd "npm install -g bower"
   # May need the following if node doesn't install correctly.
   #runAndAssertCmd "ln -s /usr/bin/nodejs /usr/bin/node"
-  runAndAssertCmd "bower install"
+  runInUfOAndAssertCmd "bower install"
 }
 
 function setupDevelopmentEnvironment ()

--- a/setup.sh
+++ b/setup.sh
@@ -177,7 +177,7 @@ function clean ()
   fi
 }
 
-function travis ()
+function testOntravis ()
 {
   fixDirectoryEnvironment
   setupAppEngine
@@ -203,7 +203,7 @@ function package ()
 
 function release ()
 {
-  travis
+  testOntravis
   runAndAssertCmd "python -m unittest discover -p '*_test.py'"
   package
   # Not sure how to automatically push this while maintaining some control over
@@ -274,7 +274,7 @@ function printHelp ()
   echo
 }
 
-function bareMetalInstall ()
+function installFromBareMetal ()
 {
   # Using variables here to make things fit on 80 character lines.
   PYTHON_DEPS1="libreadline-gplv2-dev libncursesw5-dev libssl-dev"
@@ -316,13 +316,13 @@ elif [ "$1" == 'release' ]; then
 elif [ "$1" == 'deploy' ]; then
   deploy
 elif [ "$1" == 'travis' ]; then
-  travis
+  testOntravis
 elif [ "$1" == 'setup' ]; then
   setupDevelopmentEnvironment
 elif [ "$1" == 'clean' ]; then
   clean
 elif [ "$1" == 'metal' ]; then
-  bareMetalInstall
+  installFromBareMetal
 else
   printHelp
   exit 0


### PR DESCRIPTION
One important change is that the command 'setup_tests' was renamed to just 'setup' for simplicity. 'run_tests' was also renamed to 'travis' since that seems to be the only environment in which it should be used.

Bower support allows us to install our bower dependencies correctly when running in Travis CI so that UI testing can begin sometime down the road.

The clean command allows for easy resetting of your development environment to pick up new dependencies. Simply run the following:

sudo ./setup.sh clean
./setup.sh setup

The 'metal' command should be used with caution. I added this in case we ever need to bootstrap in a completely bare metal (assuming Ubuntu flavor) OS/VM. It will install python, pip, and git for us. The rest is handled through the normal flow. I highly doubt it will be necessary, but it is nice to have as a fallback just in case.

Finally, I updated the README to reflect the changed commands and how to pick up new dependencies.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server/35)
<!-- Reviewable:end -->
