### PR TITLE
Add Support for Searching for Users in the Add Flow

### DIFF
--- a/google_directory_service.py
+++ b/google_directory_service.py
@@ -73,15 +73,17 @@ class GoogleDirectoryService(object):
 
     return users
 
-  def SearchForUser(self, user_key):
-    """Search for a user based on a user key.
+  def GetUser(self, user_key):
+    """Get a user based on a user key.
+
+    List format is used here for consistency with the other methods and to
+    simplify rendering a template based on the response.
 
     Args:
       user_key: A string identifying an individual user.
 
     Returns:
       users: A list with that user in it or empty.
-      List format is used here for consistency with the other methods.
     """
     users = []
     request = self.service.users().get(userKey=user_key, projection='full')

--- a/google_directory_service.py
+++ b/google_directory_service.py
@@ -7,6 +7,7 @@ MY_CUSTOMER_ALIAS = 'my_customer'
 
 NUM_RETRIES = 3
 
+# TODO(eholder): Write tests for these functions.
 
 class GoogleDirectoryService(object):
   """Interact with Google Directory API."""
@@ -69,6 +70,24 @@ class GoogleDirectoryService(object):
     for member in members:
       if 'type' in member and member['type'] == user:
         users.append(member)
+
+    return users
+
+  def SearchForUser(self, user_key):
+    """Search for a user based on a user key.
+
+    Args:
+      user_key: A string identifying an individual user.
+
+    Returns:
+      users: A list with that user in it or empty.
+      List format is used here for consistency with the other methods.
+    """
+    users = []
+    request = self.service.users().get(userKey=user_key, projection='full')
+    result = request.execute(num_retries=NUM_RETRIES)
+    if result['primaryEmail']:
+      users.append(result)
 
     return users
 

--- a/templates/add_user.html
+++ b/templates/add_user.html
@@ -1,32 +1,47 @@
 {% extends "templates/base.html" %}
 {% block title %}Add Users{% endblock %}
 {% block body %}
-  <form method="post" action="https://{{ host }}/user/add">
-    <br><br>
-    Select Users to Add.
-    <br><br>
-  <ul>
-  {% for directory_user in directory_users %}
-    <li>
-      <input type="checkbox" name="selected_user" value="{{ directory_user['primaryEmail'] }}">
-      {{ directory_user['primaryEmail'] }}<br>
-    </li>
-    <br />
-  {% endfor %}
-  </ul>
-    <input type="hidden" name="xsrf" value="{{ xsrf_token }}">
-    <input type="submit" value="Add Selected Users">
-  </form>
+  {% if directory_users%}
+    <form method="post" action="https://{{ host }}/user/add">
+      <br><br>
+      Select Users to Add.
+      <br><br>
+    <ul>
+    {% for directory_user in directory_users %}
+      <li>
+        <input type="checkbox" name="selected_user" value="{{ directory_user['primaryEmail'] }}">
+        {{ directory_user['primaryEmail'] }}<br>
+      </li>
+      <br />
+    {% endfor %}
+    </ul>
+      <input type="hidden" name="xsrf" value="{{ xsrf_token }}">
+      <input type="submit" value="Add Selected Users">
+    </form>
+  {% else %}
+    <p>No users found. Try another query below.</p>
+  {% endif %}
+  <br><br>
+
+
   <form method="get" action="https://{{ host }}/user/add">
     <br><br>
-    Input your group key to fetch more users.
+    Input a group key (group email address or unique id) to fetch more users.
     <br><br>
     <input type="textbox" name="group_key" value="{{ group_key }}">
     <br><br>
     <input type="submit" value="Fetch Users From Group">
-  </form>
+  </form><br>
+  <form method="get" action="https://{{ host }}/user/add">
+    <br><br>
+    Input user key (email address or unique id) to search for a specific user.
+    <br><br>
+    <input type="email" name="user_key" value="{{ user_key }}">
+    <br><br>
+    <input type="submit" value="Search for Specific User">
+  </form><br>
   <form method="get" action="https://{{ host }}/user/add">
     <input type="hidden" name="get_all" value="true">
     <input type="submit" value="Fetch All Users in Domain">
-  </form>
+  </form><br>
 {% endblock %}

--- a/templates/add_user.html
+++ b/templates/add_user.html
@@ -1,6 +1,10 @@
 {% extends "templates/base.html" %}
 {% block title %}Add Users{% endblock %}
 {% block body %}
+  {% if error%}
+    <p>An error occurred while processing the request. Please retry or select another query. The error text is below.</p>
+    <p>{{ error }}</p>
+  {% endif %}
   {% if directory_users%}
     <form method="post" action="https://{{ host }}/user/add">
       <br><br>

--- a/user.py
+++ b/user.py
@@ -255,6 +255,7 @@ class AddUsersHandler(webapp2.RequestHandler):
     """
     get_all = self.request.get('get_all')
     group_key = self.request.get('group_key')
+    user_key = self.request.get('user_key')
     if get_all:
       directory_service = GoogleDirectoryService(OAUTH_DECORATOR)
       directory_users = directory_service.GetUsers()
@@ -267,6 +268,10 @@ class AddUsersHandler(webapp2.RequestHandler):
         user['primaryEmail'] = user['email']
         fixed_users.append(user)
       self.response.write(_RenderAddUsersTemplate(fixed_users))
+    elif user_key is not None and user_key is not '':
+      directory_service = GoogleDirectoryService(OAUTH_DECORATOR)
+      directory_users = directory_service.SearchForUser(user_key)
+      self.response.write(_RenderAddUsersTemplate(directory_users))
     else:
       self.response.write(_RenderAddUsersTemplate([]))
 

--- a/user.py
+++ b/user.py
@@ -1,19 +1,20 @@
 """The module for handling users."""
 
+import admin
 from appengine_config import JINJA_ENVIRONMENT
 from auth import OAUTH_DECORATOR
 import base64
-from datastore import User
 from datastore import DomainVerification
 from datastore import ProxyServer
+from datastore import User
 from error_handlers import Handle500
+from googleapiclient import errors
 from google.appengine.api import app_identity
 from google_directory_service import GoogleDirectoryService
 import json
 import random
 import webapp2
 import xsrf
-import admin
 
 
 JINJA_ENVIRONMENT.globals['xsrf_token'] = xsrf.xsrf_token()
@@ -158,12 +159,14 @@ def _RenderLandingTemplate():
   return template.render(template_values)
 
 
-def _RenderAddUsersTemplate(directory_users):
+def _RenderAddUsersTemplate(directory_users, error=None):
   """Render a user add page that lets users be added by group key."""
   template_values = {
       'host': app_identity.get_default_version_hostname(),
       'directory_users': directory_users,
   }
+  if error is not None:
+    template_values['error'] = error
   template = JINJA_ENVIRONMENT.get_template('templates/add_user.html')
   return template.render(template_values)
 
@@ -256,24 +259,27 @@ class AddUsersHandler(webapp2.RequestHandler):
     get_all = self.request.get('get_all')
     group_key = self.request.get('group_key')
     user_key = self.request.get('user_key')
-    if get_all:
-      directory_service = GoogleDirectoryService(OAUTH_DECORATOR)
-      directory_users = directory_service.GetUsers()
-      self.response.write(_RenderAddUsersTemplate(directory_users))
-    elif group_key is not None and group_key is not '':
-      directory_service = GoogleDirectoryService(OAUTH_DECORATOR)
-      directory_users = directory_service.GetUsersByGroupKey(group_key)
-      fixed_users = []
-      for user in directory_users:
-        user['primaryEmail'] = user['email']
-        fixed_users.append(user)
-      self.response.write(_RenderAddUsersTemplate(fixed_users))
-    elif user_key is not None and user_key is not '':
-      directory_service = GoogleDirectoryService(OAUTH_DECORATOR)
-      directory_users = directory_service.SearchForUser(user_key)
-      self.response.write(_RenderAddUsersTemplate(directory_users))
-    else:
-      self.response.write(_RenderAddUsersTemplate([]))
+    try:
+      if get_all:
+        directory_service = GoogleDirectoryService(OAUTH_DECORATOR)
+        directory_users = directory_service.GetUsers()
+        self.response.write(_RenderAddUsersTemplate(directory_users))
+      elif group_key is not None and group_key is not '':
+        directory_service = GoogleDirectoryService(OAUTH_DECORATOR)
+        directory_users = directory_service.GetUsersByGroupKey(group_key)
+        fixed_users = []
+        for user in directory_users:
+          user['primaryEmail'] = user['email']
+          fixed_users.append(user)
+        self.response.write(_RenderAddUsersTemplate(fixed_users))
+      elif user_key is not None and user_key is not '':
+        directory_service = GoogleDirectoryService(OAUTH_DECORATOR)
+        directory_users = directory_service.SearchForUser(user_key)
+        self.response.write(_RenderAddUsersTemplate(directory_users))
+      else:
+        self.response.write(_RenderAddUsersTemplate([]))
+    except errors.HttpError as error:
+      self.response.write(_RenderAddUsersTemplate([], error))
 
   @admin.require_admin
   @xsrf.xsrf_protect

--- a/user.py
+++ b/user.py
@@ -274,7 +274,7 @@ class AddUsersHandler(webapp2.RequestHandler):
         self.response.write(_RenderAddUsersTemplate(fixed_users))
       elif user_key is not None and user_key is not '':
         directory_service = GoogleDirectoryService(OAUTH_DECORATOR)
-        directory_users = directory_service.SearchForUser(user_key)
+        directory_users = directory_service.GetUser(user_key)
         self.response.write(_RenderAddUsersTemplate(directory_users))
       else:
         self.response.write(_RenderAddUsersTemplate([]))

--- a/user_test.py
+++ b/user_test.py
@@ -120,12 +120,12 @@ class UserTest(unittest.TestCase):
     mock_render.assert_called_once_with([])
 
   @patch('user._RenderAddUsersTemplate')
-  @patch('google_directory_service.GoogleDirectoryService.SearchForUser')
+  @patch('google_directory_service.GoogleDirectoryService.GetUser')
   @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
   @patch('google_directory_service.GoogleDirectoryService.GetUsers')
   @patch('google_directory_service.GoogleDirectoryService.__init__')
   def testAddUsersGetHandlerWithGroup(self, mock_ds, mock_get_users,
-                                      mock_get_by_key, mock_search,
+                                      mock_get_by_key, mock_get_user,
                                       mock_render):
     mock_ds.return_value = None
     # Email address could refer to group or user
@@ -134,56 +134,56 @@ class UserTest(unittest.TestCase):
     response = self.testapp.get('/user/add?group_key=' + group_key)
 
     mock_get_users.assert_not_called()
-    mock_search.assert_not_called()
+    mock_get_user.assert_not_called()
     mock_ds.assert_called_once_with(mock_auth.OAUTH_DECORATOR)
     mock_get_by_key.assert_called_once_with(group_key)
     mock_render.assert_called_once_with(FAKE_USER_ARRAY)
 
   @patch('user._RenderAddUsersTemplate')
-  @patch('google_directory_service.GoogleDirectoryService.SearchForUser')
+  @patch('google_directory_service.GoogleDirectoryService.GetUser')
   @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
   @patch('google_directory_service.GoogleDirectoryService.GetUsers')
   @patch('google_directory_service.GoogleDirectoryService.__init__')
   def testAddUsersGetHandlerWithUser(self, mock_ds, mock_get_users,
-                                     mock_get_by_key, mock_search,
+                                     mock_get_by_key, mock_get_user,
                                      mock_render):
     mock_ds.return_value = None
     # Email address could refer to group or user
     user_key = 'foo@bar.mybusiness.com'
-    mock_search.return_value = FAKE_USER_ARRAY
+    mock_get_user.return_value = FAKE_USER_ARRAY
     response = self.testapp.get('/user/add?user_key=' + user_key)
 
     mock_get_users.assert_not_called()
     mock_get_by_key.assert_not_called()
     mock_ds.assert_called_once_with(mock_auth.OAUTH_DECORATOR)
-    mock_search.assert_called_once_with(user_key)
+    mock_get_user.assert_called_once_with(user_key)
     mock_render.assert_called_once_with(FAKE_USER_ARRAY)
 
   @patch('user._RenderAddUsersTemplate')
-  @patch('google_directory_service.GoogleDirectoryService.SearchForUser')
+  @patch('google_directory_service.GoogleDirectoryService.GetUser')
   @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
   @patch('google_directory_service.GoogleDirectoryService.GetUsers')
   @patch('google_directory_service.GoogleDirectoryService.__init__')
   def testAddUsersGetHandlerWithAll(self, mock_ds, mock_get_users,
-                                    mock_get_by_key, mock_search,
+                                    mock_get_by_key, mock_get_user,
                                     mock_render):
     mock_ds.return_value = None
     mock_get_users.return_value = FAKE_USER_ARRAY
     response = self.testapp.get('/user/add?get_all=true')
 
     mock_get_by_key.assert_not_called()
-    mock_search.assert_not_called()
+    mock_get_user.assert_not_called()
     mock_ds.assert_called_once_with(mock_auth.OAUTH_DECORATOR)
     mock_get_users.assert_called_once_with()
     mock_render.assert_called_once_with(FAKE_USER_ARRAY)
 
   @patch('user._RenderAddUsersTemplate')
-  @patch('google_directory_service.GoogleDirectoryService.SearchForUser')
+  @patch('google_directory_service.GoogleDirectoryService.GetUser')
   @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
   @patch('google_directory_service.GoogleDirectoryService.GetUsers')
   @patch('google_directory_service.GoogleDirectoryService.__init__')
   def testAddUsersGetHandlerWithError(self, mock_ds, mock_get_users,
-                                      mock_get_by_key, mock_search,
+                                      mock_get_by_key, mock_get_user,
                                       mock_render):
     fake_status = '404'
     fake_response = MagicMock(status=fake_status)
@@ -195,7 +195,7 @@ class UserTest(unittest.TestCase):
 
     mock_ds.assert_called_once_with(mock_auth.OAUTH_DECORATOR)
     mock_get_by_key.assert_not_called()
-    mock_search.assert_not_called()
+    mock_get_user.assert_not_called()
     mock_get_users.assert_not_called()
     mock_render.assert_called_once_with([], fake_error)
 

--- a/user_test.py
+++ b/user_test.py
@@ -5,6 +5,7 @@ import sys
 import base64
 from datastore import User
 from datastore import ProxyServer
+from googleapiclient import errors
 from google.appengine.ext import ndb
 import hashlib
 import json
@@ -176,6 +177,28 @@ class UserTest(unittest.TestCase):
     mock_get_users.assert_called_once_with()
     mock_render.assert_called_once_with(FAKE_USER_ARRAY)
 
+  @patch('user._RenderAddUsersTemplate')
+  @patch('google_directory_service.GoogleDirectoryService.SearchForUser')
+  @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
+  @patch('google_directory_service.GoogleDirectoryService.GetUsers')
+  @patch('google_directory_service.GoogleDirectoryService.__init__')
+  def testAddUsersGetHandlerWithError(self, mock_ds, mock_get_users,
+                                      mock_get_by_key, mock_search,
+                                      mock_render):
+    fake_status = '404'
+    fake_response = MagicMock(status=fake_status)
+    fake_content = b'some error content'
+    fake_error = errors.HttpError(fake_response, fake_content)
+    mock_ds.side_effect = fake_error
+    mock_get_users.return_value = FAKE_USER_ARRAY
+    response = self.testapp.get('/user/add?get_all=true')
+
+    mock_ds.assert_called_once_with(mock_auth.OAUTH_DECORATOR)
+    mock_get_by_key.assert_not_called()
+    mock_search.assert_not_called()
+    mock_get_users.assert_not_called()
+    mock_render.assert_called_once_with([], fake_error)
+
   @patch('user.User.InsertUsers')
   def testAddUsersPostHandler(self, mock_insert):
     user_1 = {}
@@ -195,8 +218,7 @@ class UserTest(unittest.TestCase):
 
     mock_insert.assert_called_once_with(user_array)
     self.assertEqual(response.status_int, 302)
-    # TODO(eholder): Figure out why this test fails but works on appspot.
-    # self.assertTrue('/user' in response.location)
+    self.assertTrue('/user' in response.location)
 
   @patch('user._GenerateUserPayload')
   @patch('user.User.GetAll')
@@ -276,11 +298,19 @@ class UserTest(unittest.TestCase):
     no_user_string = 'No users found. Try another query below.'
     self.assertTrue(no_user_string in add_users_template)
     self.assertTrue('xsrf' not in add_users_template)
+    self.assertTrue('An error occurred while' not in add_users_template)
 
   def testRenderAddUsersTemplateWithSomeUsers(self):
     add_users_template = user._RenderAddUsersTemplate(FAKE_USER_ARRAY)
     self.assertTrue('Add Selected Users' in add_users_template)
     self.assertTrue('xsrf' in add_users_template)
+    self.assertTrue('An error occurred while' not in add_users_template)
+
+  def testRenderAddUsersTemplateWithError(self):
+    fake_error = 'foo bar happened causing baz'
+    add_users_template = user._RenderAddUsersTemplate([], fake_error)
+    self.assertTrue('An error occurred while' in add_users_template)
+    self.assertTrue(fake_error in add_users_template)
 
   @patch.object(user.User, 'key')
   def testGenerateTokenPayload(self, mock_url_key):


### PR DESCRIPTION
Also adds basic exception handling for Directory API calls. Since these tend to raise an exception whenever the request is not successful, the new handling allows us to fail gracefully and display the error to the user. It could still be much more robust, but at least we now do not show a random error page with nothing else. The default page behavior on error is to show the add user page with no users and list the error.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server/36)
<!-- Reviewable:end -->
