### PR TITLE
Fix Group Add to Lookup Users in Order to Get Necessary Properties

### DIFF
--- a/google_directory_service.py
+++ b/google_directory_service.py
@@ -68,12 +68,26 @@ class GoogleDirectoryService(object):
     user = 'USER'
     # Limit to only users, not groups
     for member in members:
-      if 'type' in member and member['type'] == user:
-        users.append(member)
+      if 'type' in member and member['type'] == user and member['id']:
+        users.append(self.GetUser(member['id']))
 
     return users
 
   def GetUser(self, user_key):
+    """Get a user based on a user key.
+
+    Args:
+      user_key: A string identifying an individual user.
+
+    Returns:
+      users: The user if found.
+    """
+    request = self.service.users().get(userKey=user_key, projection='full')
+    result = request.execute(num_retries=NUM_RETRIES)
+
+    return result
+
+  def GetUserAsList(self, user_key):
     """Get a user based on a user key.
 
     List format is used here for consistency with the other methods and to
@@ -86,8 +100,7 @@ class GoogleDirectoryService(object):
       users: A list with that user in it or empty.
     """
     users = []
-    request = self.service.users().get(userKey=user_key, projection='full')
-    result = request.execute(num_retries=NUM_RETRIES)
+    result = self.GetUser(user_key)
     if result['primaryEmail']:
       users.append(result)
 

--- a/templates/add_user.html
+++ b/templates/add_user.html
@@ -10,15 +10,20 @@
       <br><br>
       Select Users to Add.
       <br><br>
-    <ul>
-    {% for directory_user in directory_users %}
-      <li>
-        <input type="checkbox" name="selected_user" value="{{ directory_user['primaryEmail'] }}">
-        {{ directory_user['primaryEmail'] }}<br>
-      </li>
-      <br />
-    {% endfor %}
-    </ul>
+      <table>
+        <tr>
+          <th>-</th>
+          <th>Name</th>
+          <th>Email</th>
+        </tr>
+      {% for directory_user in directory_users %}
+        <tr>
+          <td><input type="checkbox" name="selected_user" value="{{ directory_user }}"></td>
+          <td>{{ directory_user['name']['fullName'] }}</td>
+          <td>{{ directory_user['primaryEmail'] }}</td>
+        </tr>
+      {% endfor %}
+      </table>
       <input type="hidden" name="xsrf" value="{{ xsrf_token }}">
       <input type="submit" value="Add Selected Users">
     </form>

--- a/user_test.py
+++ b/user_test.py
@@ -48,6 +48,8 @@ FAKE_EMAIL_1 = u'foo@business.com'
 FAKE_EMAIL_2 = u'bar@business.com'
 FAKE_ADD_USER = {}
 FAKE_ADD_USER['primaryEmail'] = FAKE_EMAIL_1
+FAKE_ADD_USER['name'] = {}
+FAKE_ADD_USER['name']['fullName'] = FAKE_NAME
 FAKE_ADD_USER['email'] = FAKE_EMAIL_1
 FAKE_ADD_USER['role'] = 'MEMBER'
 FAKE_ADD_USER['type'] = 'USER'
@@ -107,20 +109,23 @@ class UserTest(unittest.TestCase):
     mock_token_template.assert_called_once_with()
 
   @patch('user._RenderAddUsersTemplate')
+  @patch('google_directory_service.GoogleDirectoryService.GetUserAsList')
   @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
   @patch('google_directory_service.GoogleDirectoryService.GetUsers')
   @patch('google_directory_service.GoogleDirectoryService.__init__')
   def testAddUsersGetHandlerNoParam(self, mock_ds, mock_get_users,
-                                    mock_get_by_key, mock_render):
+                                    mock_get_by_key, mock_get_user,
+                                    mock_render):
     response = self.testapp.get('/user/add')
 
     mock_ds.assert_not_called()
     mock_get_users.assert_not_called()
+    mock_get_user.assert_not_called()
     mock_get_by_key.assert_not_called()
     mock_render.assert_called_once_with([])
 
   @patch('user._RenderAddUsersTemplate')
-  @patch('google_directory_service.GoogleDirectoryService.GetUser')
+  @patch('google_directory_service.GoogleDirectoryService.GetUserAsList')
   @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
   @patch('google_directory_service.GoogleDirectoryService.GetUsers')
   @patch('google_directory_service.GoogleDirectoryService.__init__')
@@ -140,7 +145,7 @@ class UserTest(unittest.TestCase):
     mock_render.assert_called_once_with(FAKE_USER_ARRAY)
 
   @patch('user._RenderAddUsersTemplate')
-  @patch('google_directory_service.GoogleDirectoryService.GetUser')
+  @patch('google_directory_service.GoogleDirectoryService.GetUserAsList')
   @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
   @patch('google_directory_service.GoogleDirectoryService.GetUsers')
   @patch('google_directory_service.GoogleDirectoryService.__init__')
@@ -160,7 +165,7 @@ class UserTest(unittest.TestCase):
     mock_render.assert_called_once_with(FAKE_USER_ARRAY)
 
   @patch('user._RenderAddUsersTemplate')
-  @patch('google_directory_service.GoogleDirectoryService.GetUser')
+  @patch('google_directory_service.GoogleDirectoryService.GetUserAsList')
   @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
   @patch('google_directory_service.GoogleDirectoryService.GetUsers')
   @patch('google_directory_service.GoogleDirectoryService.__init__')
@@ -178,7 +183,7 @@ class UserTest(unittest.TestCase):
     mock_render.assert_called_once_with(FAKE_USER_ARRAY)
 
   @patch('user._RenderAddUsersTemplate')
-  @patch('google_directory_service.GoogleDirectoryService.GetUser')
+  @patch('google_directory_service.GoogleDirectoryService.GetUserAsList')
   @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
   @patch('google_directory_service.GoogleDirectoryService.GetUsers')
   @patch('google_directory_service.GoogleDirectoryService.__init__')
@@ -212,8 +217,7 @@ class UserTest(unittest.TestCase):
     user_array = []
     user_array.append(user_1)
     user_array.append(user_2)
-    data = '?selected_user={0}&selected_user={1}'.format(FAKE_EMAIL_1,
-                                                         FAKE_EMAIL_2)
+    data = '?selected_user={0}&selected_user={1}'.format(user_1, user_2)
     response = self.testapp.post('/user/add' + data)
 
     mock_insert.assert_called_once_with(user_array)


### PR DESCRIPTION
This allows us to insert users from a group query while retaining their name property. The group API returns data in this form: https://developers.google.com/admin-sdk/directory/v1/reference/members/list#response

However, that format only lists members with kind, etag, id, email, role, and type fields (no name). So since we now have an easy method to get a user, I just supply the id tag since it is another unique identifier.

In the future, we could look at doing a batch operation to get all users in the domain and then diff between the domain users and group users to select the ones we need with all necessary properties. This would cut down on the amount of calls being made in the event of a group having lots of users. That requires more logic on our part, so for now I'm avoiding it, but it is something that can be improved upon.

I also changed how the users are displayed in the add user flow to use a table. Seems to be a bit cleaner and makes it easier to quickly find whatever user an admin may be looking for.

Also I separated out the GetUser method into a regular version that just returns the user (for the group method to call) and a list version (for the template render to consume).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server/37)
<!-- Reviewable:end -->
