### PR TITLE
Cleanup our Global Definitions

### DIFF
--- a/appengine_config.py
+++ b/appengine_config.py
@@ -17,8 +17,8 @@ JINJA_ENVIRONMENT = jinja2.Environment(
 
 
 JINJA_ENVIRONMENT.globals['xsrf_token'] = xsrf.xsrf_token()
-_host = str(app_identity.get_default_version_hostname())
-JINJA_ENVIRONMENT.globals['BASE_URL'] = ('https://' + _host)
+HOST = str(app_identity.get_default_version_hostname())
+JINJA_ENVIRONMENT.globals['BASE_URL'] = ('https://' + HOST)
 
 # Add any libraries installed in the "lib" folder.
 vendor.add('lib')

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -1,9 +1,10 @@
 """Custom configurations for Google App Engine."""
 
-import os
-import jinja2
-
+from google.appengine.api import app_identity
 from google.appengine.ext import vendor
+import jinja2
+import os
+import xsrf
 
 
 ROOT = os.path.dirname(__file__)
@@ -14,6 +15,10 @@ JINJA_ENVIRONMENT = jinja2.Environment(
                 'jinja2.ext.i18n'],
     autoescape=True)
 
+
+JINJA_ENVIRONMENT.globals['xsrf_token'] = xsrf.xsrf_token()
+_host = str(app_identity.get_default_version_hostname())
+JINJA_ENVIRONMENT.globals['BASE_URL'] = ('https://' + _host)
 
 # Add any libraries installed in the "lib" folder.
 vendor.add('lib')

--- a/proxy_server.py
+++ b/proxy_server.py
@@ -11,8 +11,6 @@ from datastore import ProxyServer
 from datastore import User
 import xsrf
 
-from google.appengine.api import app_identity
-
 
 
 def _RenderProxyServerFormTemplate(proxy_server):

--- a/proxy_server.py
+++ b/proxy_server.py
@@ -18,7 +18,6 @@ from google.appengine.api import app_identity
 def _RenderProxyServerFormTemplate(proxy_server):
   """Render the form to add or edit a proxy server."""
   template_values = {
-      'host': app_identity.get_default_version_hostname(),
       'proxy_server': proxy_server,
       'xsrf_token': xsrf.xsrf_token(),
   }
@@ -30,7 +29,6 @@ def _RenderListProxyServerTemplate():
   """Render a list of proxy servers."""
   proxy_servers = ProxyServer.GetAll()
   template_values = {
-      'host': app_identity.get_default_version_hostname(),
       'proxy_servers': proxy_servers
   }
   template = JINJA_ENVIRONMENT.get_template('templates/proxy_server.html')

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ import xsrf
 import admin
 
 
-JINJA_ENVIRONMENT.globals['xsrf_token'] = xsrf.xsrf_token()
 
 
 def _RenderSetupOAuthClientTemplate():
@@ -21,7 +20,6 @@ def _RenderSetupOAuthClientTemplate():
   entity = OAuth.GetOrInsertDefault()
   domain_verification = DomainVerification.GetOrInsertDefault()
   template_values = {
-      'host': app_identity.get_default_version_hostname(),
       'client_id': entity.client_id,
       'client_secret': entity.client_secret,
       'dv_content': domain_verification.content,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from datastore import User
 from datastore import OAuth
 from datastore import DomainVerification
 from error_handlers import Handle500
-from google.appengine.api import app_identity
 import json
 import webapp2
 import xsrf

--- a/templates/add_user.html
+++ b/templates/add_user.html
@@ -6,7 +6,7 @@
     <p>{{ error }}</p>
   {% endif %}
   {% if directory_users%}
-    <form method="post" action="https://{{ host }}/user/add">
+    <form method="post" action="{{ BASE_URL }}/user/add">
       <br><br>
       Select Users to Add.
       <br><br>
@@ -33,7 +33,7 @@
   <br><br>
 
 
-  <form method="get" action="https://{{ host }}/user/add">
+  <form method="get" action="{{ BASE_URL }}/user/add">
     <br><br>
     Input a group key (group email address or unique id) to fetch more users.
     <br><br>
@@ -41,7 +41,7 @@
     <br><br>
     <input type="submit" value="Fetch Users From Group">
   </form><br>
-  <form method="get" action="https://{{ host }}/user/add">
+  <form method="get" action="{{ BASE_URL }}/user/add">
     <br><br>
     Input user key (email address or unique id) to search for a specific user.
     <br><br>
@@ -49,7 +49,7 @@
     <br><br>
     <input type="submit" value="Search for Specific User">
   </form><br>
-  <form method="get" action="https://{{ host }}/user/add">
+  <form method="get" action="{{ BASE_URL }}/user/add">
     <input type="hidden" name="get_all" value="true">
     <input type="submit" value="Fetch All Users in Domain">
   </form><br>

--- a/templates/proxy_server.html
+++ b/templates/proxy_server.html
@@ -1,7 +1,7 @@
 {% extends "templates/base.html" %}
 {% block title %}Proxy Server(s){% endblock %}
 {% block body %}
-  <a href="https://{{ host }}/proxyserver/add">add new proxy server</a><br><br>
+  <a href="{{ BASE_URL }}/proxyserver/add">add new proxy server</a><br><br>
   name, ip address, private key, fingerprint
   <ul>
   {% for proxy_server in proxy_servers %}
@@ -10,11 +10,11 @@
       {{ proxy_server.ip_address }},
       {{ proxy_server.ssh_private_key }},
       {{ proxy_server.fingerprint }}
-      <a href="https://{{ host }}/proxyserver/edit?id={{ proxy_server.key.id() }}">
+      <a href="{{ BASE_URL }}/proxyserver/edit?id={{ proxy_server.key.id() }}">
         edit
       </a>
       &bull;
-      <a href="https://{{ host }}/proxyserver/delete?id={{ proxy_server.key.id() }}">
+      <a href="{{ BASE_URL }}/proxyserver/delete?id={{ proxy_server.key.id() }}">
         delete
       </a>
     </li>

--- a/templates/proxy_server_form.html
+++ b/templates/proxy_server_form.html
@@ -2,7 +2,7 @@
 {% block title %}Proxy Server(s){% endblock %}
 {% block body %}
   {% if proxy_server %}
-    <form method="post" action="https://{{ host }}/proxyserver/edit">
+    <form method="post" action="{{ BASE_URL }}/proxyserver/edit">
       ip address:<br>
       <input type="text" name="ip_address" value="{{ proxy_server.ip_address }}"><br>
       name:<br>
@@ -13,7 +13,7 @@
       <input type="text" name="fingerprint" value="{{ proxy_server.fingerprint }}">
       <input type="hidden" name="id" value="{{ proxy_server.key.id() }}">
   {% else %}
-    <form method="post" action="https://{{ host }}/proxyserver/add">
+    <form method="post" action="{{ BASE_URL }}/proxyserver/add">
       ip address:<br>
       <input type="text" name="ip_address" value="{{ proxy_server.ip_address }}"><br>
       name:<br>

--- a/templates/setup_client.html
+++ b/templates/setup_client.html
@@ -1,7 +1,7 @@
 {% extends "templates/base.html" %}
 {% block title %}Setup OAuth Client{% endblock %}
 {% block body %}
-  <form method="post" action="https://{{ host }}/setup/oauthclient">
+  <form method="post" action="{{ BASE_URL }}/setup/oauthclient">
     client_id:<br>
     <input type="text" name="client_id" value="{{ client_id }}">
     <br>

--- a/templates/token.html
+++ b/templates/token.html
@@ -5,9 +5,9 @@
   {% for key, (email, token_payload) in user_token_payloads.iteritems() %}
     <li>
       <b>{{ email }}</b>
-      <a href="http://{{ host }}/user/getNewToken?key={{ key }}">(Get New Token)</a>
+      <a href="{{ BASE_URL }}/user/getNewToken?key={{ key }}">(Get New Token)</a>
       <br />
-      token_payload: {{ token_payload }} &nbsp;&nbsp;&nbsp; 
+      token_payload: {{ token_payload }} &nbsp;&nbsp;&nbsp;
       <br />
     </li>
     <br />

--- a/templates/user.html
+++ b/templates/user.html
@@ -1,8 +1,8 @@
 {% extends "templates/base.html" %}
 {% block title %}Users{% endblock %}
 {% block body %}
-  <a href="http://{{ host }}/user/add">Add Users</a><br />
-  <a href="http://{{ host }}/user/listTokens">List Tokens</a><br />
+  <a href="{{ BASE_URL }}/user/add">Add Users</a><br />
+  <a href="{{ BASE_URL }}/user/listTokens">List Tokens</a><br />
   {% if invite_code %}
     <h4>Invite Code Below</h4>
     <textarea rows="20" cols="80">{{ invite_code }}</textarea><br>
@@ -10,11 +10,11 @@
   <ul>
   {% for key, email in user_payloads.iteritems() %}
     <li>{{ email }}
-      <a href="http://{{ host }}/user/delete?key={{ key }}">(Delete User)</a>
-      <a href="http://{{ host }}/user/getInviteCode?key={{ key }}">
+      <a href="{{ BASE_URL }}/user/delete?key={{ key }}">(Delete User)</a>
+      <a href="{{ BASE_URL }}/user/getInviteCode?key={{ key }}">
         (Get Invite Code)</a>
       <br />
-      <a href="http://{{ host }}/user/getNewToken?key={{ key }}">
+      <a href="{{ BASE_URL }}/user/getNewToken?key={{ key }}">
         (Get New Token)</a>
     </li>
     <br />

--- a/user.py
+++ b/user.py
@@ -18,7 +18,6 @@ import webapp2
 import xsrf
 
 
-JINJA_ENVIRONMENT.globals['xsrf_token'] = xsrf.xsrf_token()
 
 
 def _GenerateTokenPayload(users):
@@ -128,7 +127,6 @@ def _RenderUserListTemplate(invite_code=None):
   users = User.GetAll()
   user_payloads = _GenerateUserPayload(users)
   template_values = {
-      'host': app_identity.get_default_version_hostname(),
       'user_payloads': user_payloads
   }
   if invite_code is not None:
@@ -143,7 +141,6 @@ def _RenderTokenListTemplate():
   user_token_payloads = _GenerateTokenPayload(users)
 
   template_values = {
-      'host': app_identity.get_default_version_hostname(),
       'user_token_payloads': user_token_payloads
   }
   template = JINJA_ENVIRONMENT.get_template('templates/token.html')
@@ -153,7 +150,6 @@ def _RenderTokenListTemplate():
 def _RenderLandingTemplate():
   """Render the default landing page."""
   template_values = {
-      'host': app_identity.get_default_version_hostname(),
       'site_verification_content': DomainVerification.GetOrInsertDefault().content,
   }
   template = JINJA_ENVIRONMENT.get_template('templates/landing.html')
@@ -163,7 +159,6 @@ def _RenderLandingTemplate():
 def _RenderAddUsersTemplate(directory_users, error=None):
   """Render a user add page that lets users be added by group key."""
   template_values = {
-      'host': app_identity.get_default_version_hostname(),
       'directory_users': directory_users,
   }
   if error is not None:

--- a/user.py
+++ b/user.py
@@ -10,7 +10,6 @@ from datastore import ProxyServer
 from datastore import User
 from error_handlers import Handle500
 from googleapiclient import errors
-from google.appengine.api import app_identity
 from google_directory_service import GoogleDirectoryService
 import json
 import random


### PR DESCRIPTION
Set jinja environment globals in the appengine config once so each handler class can pick those up without duplication. Also change the host parameter over to BASE_URL instead which also specifies https:// before the host so everything is over https.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server/38)
<!-- Reviewable:end -->
