### PR TITLE
Swap Out Native HTML Elements for Polymer Ones Where Possible

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -18,6 +18,14 @@ handlers:
 - url: /static
   static_dir: static
 
+- url: /js
+  static_dir: js
+  secure: always
+
+- url: /css
+  static_dir: css
+  secure: always
+
 - url: /logout.*
   script: logout.app
   login: required

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,23 @@
 {
   "name": "ufo-management-server",
   "dependencies": {
+    "iron-form": "PolymerElements/iron-form#~1.0.13",
     "polymer": "~1.2.3",
+    "paper-button": "PolymerElements/paper-button#~1.0.10",
+    "paper-card": "PolymerElements/paper-card#~1.0.8",
+    "paper-checkbox": "PolymerElements/paper-checkbox#~1.0.16",
     "paper-drawer-panel": "PolymerElements/paper-drawer-panel#~1.0.5",
-    "paper-toolbar": "PolymerElements/paper-toolbar#~1.1.1",
+    "paper-input": "PolymerElements/paper-input#~1.1.2",
+    "paper-item": "PolymerElements/paper-item#~1.1.2",
+    "paper-listbox": "PolymerElements/paper-listbox#~1.1.0",
     "paper-menu": "PolymerElements/paper-menu#~1.2.0",
-    "paper-item": "PolymerElements/paper-item#~1.1.2"
+    "paper-toolbar": "PolymerElements/paper-toolbar#~1.1.1"
+  },
+  "resolutions": {
+    "polymer": "~1.2.3",
+    "paper-ripple": "^1.0.0",
+    "paper-item": "~1.1.2",
+    "webcomponentsjs": "0.7.19",
+    "paper-button": "~1.0.10"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "ufo-management-server",
   "dependencies": {
+    "iron-collapse": "PolymerElements/iron-collapse#~1.0.4",
     "iron-form": "PolymerElements/iron-form#~1.0.13",
     "polymer": "~1.2.3",
     "paper-button": "PolymerElements/paper-button#~1.0.10",

--- a/css/custom.css
+++ b/css/custom.css
@@ -11,6 +11,10 @@ paper-card {
   background-color: inherit;
 }
 
+.top-buttons {
+  margin-bottom: 16px;
+}
+
 #main-section {
   margin-left: 16px;
   margin-top: 16px;

--- a/css/custom.css
+++ b/css/custom.css
@@ -1,0 +1,25 @@
+body {
+	background-color: #fafafa;
+}
+
+paper-card {
+  margin-bottom: 16px;
+}
+
+.anchor-button {
+  color: inherit;
+  background-color: inherit;
+}
+
+#main-section {
+  margin-left: 16px;
+  margin-top: 16px;
+}
+
+#setup-form {
+  max-width: 800px;
+}
+
+#proxy-card-holder {
+  max-width: 800px;
+}

--- a/js/helperFunctions.js
+++ b/js/helperFunctions.js
@@ -1,3 +1,7 @@
 var submitByFormId = function(formId) {
   document.getElementById(formId).submit();
 };
+
+var toggleCollapse = function(collapseId) {
+  document.getElementById(collapseId).toggle();
+};

--- a/js/helperFunctions.js
+++ b/js/helperFunctions.js
@@ -1,0 +1,3 @@
+var submitByFormId = function(formId) {
+  document.getElementById(formId).submit();
+};

--- a/proxy_server_test.py
+++ b/proxy_server_test.py
@@ -114,8 +114,8 @@ class ProxyServerTest(unittest.TestCase):
     add_form = proxy_server._RenderProxyServerFormTemplate(None)
     self.assertTrue('/proxyserver/add' in add_form)
     self.assertFalse('/proxyserver/edit' in add_form)
-    self.assertTrue('name:' in add_form)
-    self.assertTrue('ip address:' in add_form)
+    self.assertTrue('Name' in add_form)
+    self.assertTrue('IP Address' in add_form)
 
   def testRenderEditProxyServerTemplate(self):
     fake_proxy_server = GetFakeProxyServer()
@@ -124,9 +124,9 @@ class ProxyServerTest(unittest.TestCase):
     self.assertTrue('/proxyserver/edit' in edit_form)
     # TODO(henryc): We need better asserts on the exact elements and their
     # values.  Will circle back once the UI is in shape.
-    self.assertTrue('name:' in edit_form)
+    self.assertTrue('Name' in edit_form)
     self.assertTrue(FAKE_NAME in edit_form)
-    self.assertTrue('ip address:' in edit_form)
+    self.assertTrue('IP Address' in edit_form)
     self.assertTrue(FAKE_IP_ADDRESS in edit_form)
 
   @patch('datastore.ProxyServer.GetAll')
@@ -136,7 +136,7 @@ class ProxyServerTest(unittest.TestCase):
     mock_get_all.return_value = fake_proxy_servers
     list_proxy_server_template = proxy_server._RenderListProxyServerTemplate()
 
-    self.assertTrue('add new proxy server' in list_proxy_server_template)
+    self.assertTrue('Add New Proxy Server' in list_proxy_server_template)
     self.assertTrue(FAKE_NAME in list_proxy_server_template)
     self.assertTrue(FAKE_IP_ADDRESS in list_proxy_server_template)
     self.assertTrue(FAKE_SSH_PRIVATE_KEY in list_proxy_server_template)

--- a/setup_test.py
+++ b/setup_test.py
@@ -99,9 +99,9 @@ class SetupTest(unittest.TestCase):
 
     setup_client_template = setup._RenderSetupOAuthClientTemplate()
 
-    self.assertTrue('client_id:' in setup_client_template)
-    self.assertTrue('client_secret:' in setup_client_template)
-    self.assertTrue('Domain Verification Meta Tag Content:' in setup_client_template)
+    self.assertTrue('Client ID' in setup_client_template)
+    self.assertTrue('Client Secret' in setup_client_template)
+    self.assertTrue('Domain Verification Meta Tag Content' in setup_client_template)
     self.assertTrue('xsrf' in setup_client_template)
     self.assertTrue(FAKE_ID in setup_client_template)
     self.assertTrue(FAKE_SECRET in setup_client_template)

--- a/templates/add_user.html
+++ b/templates/add_user.html
@@ -1,15 +1,17 @@
 {% extends "templates/base.html" %}
 {% block title %}Add Users{% endblock %}
+{% block head %}
+  <link rel="import" href="/bower_components/paper-button/paper-button.html" />
+  <link rel="import" href="/bower_components/paper-input/paper-input.html" />
+{% endblock %}
 {% block body %}
   {% if error%}
     <p>An error occurred while processing the request. Please retry or select another query. The error text is below.</p>
     <p>{{ error }}</p>
   {% endif %}
   {% if directory_users%}
-    <form method="post" action="{{ BASE_URL }}/user/add">
-      <br><br>
-      Select Users to Add.
-      <br><br>
+    <form id="users-add-form" method="post" action="{{ BASE_URL }}/user/add">
+      <p>Select Users to Add.</p>
       <table>
         <tr>
           <th>-</th>
@@ -18,6 +20,8 @@
         </tr>
       {% for directory_user in directory_users %}
         <tr>
+          <!-- Paper checkbox doesn't work without manually collecting values
+          in javascript so we aren't using that yet. -->
           <td><input type="checkbox" name="selected_user" value="{{ directory_user }}"></td>
           <td>{{ directory_user['name']['fullName'] }}</td>
           <td>{{ directory_user['primaryEmail'] }}</td>
@@ -25,7 +29,7 @@
       {% endfor %}
       </table>
       <input type="hidden" name="xsrf" value="{{ xsrf_token }}">
-      <input type="submit" value="Add Selected Users">
+      <paper-button raised onclick="submitByFormId('users-add-form')" class="form-submit-button" type="submit">Add Selected Users</paper-button>
     </form>
   {% else %}
     <p>No users found. Try another query below.</p>
@@ -33,24 +37,20 @@
   <br><br>
 
 
-  <form method="get" action="{{ BASE_URL }}/user/add">
-    <br><br>
-    Input a group key (group email address or unique id) to fetch more users.
-    <br><br>
-    <input type="textbox" name="group_key" value="{{ group_key }}">
-    <br><br>
-    <input type="submit" value="Fetch Users From Group">
+  <form id="users-group-form" method="get" action="{{ BASE_URL }}/user/add">
+    <paper-input label="Input a group key (group email address or unique id) to fetch more users." type="textbox" name="group_key" value="{{ group_key }}">
+    </paper-input>
+    <paper-button raised onclick="submitByFormId('users-group-form')" class="form-submit-button" type="submit">Fetch Users From Group</paper-button>
   </form><br>
-  <form method="get" action="{{ BASE_URL }}/user/add">
-    <br><br>
-    Input user key (email address or unique id) to search for a specific user.
-    <br><br>
-    <input type="email" name="user_key" value="{{ user_key }}">
-    <br><br>
-    <input type="submit" value="Search for Specific User">
+
+  <form id="users-user-form" method="get" action="{{ BASE_URL }}/user/add">
+    <paper-input label="Input user key (email address or unique id) to search for a specific user." type="email" name="user_key" value="{{ user_key }}">
+    </paper-input>
+    <paper-button raised onclick="submitByFormId('users-user-form')" class="form-submit-button" type="submit">Search for Specific User</paper-button>
   </form><br>
-  <form method="get" action="{{ BASE_URL }}/user/add">
+
+  <form id="users-domain-form" method="get" action="{{ BASE_URL }}/user/add">
     <input type="hidden" name="get_all" value="true">
-    <input type="submit" value="Fetch All Users in Domain">
+    <paper-button raised onclick="submitByFormId('users-domain-form')" class="form-submit-button" type="submit">Fetch All Users in Domain</paper-button>
   </form><br>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
     <link rel="import" href="/bower_components/polymer/polymer.html" />
     <link rel="import" href="/bower_components/paper-drawer-panel/paper-drawer-panel.html" />
     <link rel="import" href="/static/sidebar.html" />
+    <link rel="stylesheet" href="/css/custom.css" />
     {% block head %}
     {% endblock %}
 </head>
@@ -13,9 +14,10 @@
         <div drawer>
             <ufo-sidebar></ufo-sidebar>
         </div>
-        <section main class="fit">
+        <section main id="main-section" class="fit">
             {% block body %}{% endblock %}
         </section>
     </paper-drawer-panel>
+    <script src="{{ BASE_URL }}/js/helperFunctions.js"></script>
 </body>
 </html>

--- a/templates/proxy_server.html
+++ b/templates/proxy_server.html
@@ -1,24 +1,29 @@
 {% extends "templates/base.html" %}
 {% block title %}Proxy Server(s){% endblock %}
+{% block head %}
+  <link rel="import" href="/bower_components/paper-button/paper-button.html" />
+  <link rel="import" href="/bower_components/paper-card/paper-card.html" />
+{% endblock %}
 {% block body %}
-  <a href="{{ BASE_URL }}/proxyserver/add">add new proxy server</a><br><br>
-  name, ip address, private key, fingerprint
-  <ul>
+  <a href="{{ BASE_URL }}/proxyserver/add">
+    <paper-button raised class="anchor-button">Add New Proxy Server
+    </paper-button></a>
+  <p>Name, IP Address, Private Key, Fingerprint</p>
+  <div id="proxy-card-holder"/>
   {% for proxy_server in proxy_servers %}
-    <li>
-      {{ proxy_server.name }},
-      {{ proxy_server.ip_address }},
-      {{ proxy_server.ssh_private_key }},
-      {{ proxy_server.fingerprint }}
-      <a href="{{ BASE_URL }}/proxyserver/edit?id={{ proxy_server.key.id() }}">
-        edit
-      </a>
-      &bull;
-      <a href="{{ BASE_URL }}/proxyserver/delete?id={{ proxy_server.key.id() }}">
-        delete
-      </a>
-    </li>
-    <br>
+    <paper-card heading="{{ proxy_server.name }}">
+      <div class="card-content">
+        <p>{{ proxy_server.ip_address }},
+        {{ proxy_server.ssh_private_key }},
+        {{ proxy_server.fingerprint }}</p>
+      </div>
+      <div class="card-actions">
+        <a href="{{ BASE_URL }}/proxyserver/edit?id={{ proxy_server.key.id() }}">
+          <paper-button class="anchor-button">Edit</paper-button></a>
+        <a href="{{ BASE_URL }}/proxyserver/delete?id={{ proxy_server.key.id() }}">
+          <paper-button class="anchor-button">Delete</paper-button></a>
+      </div>
+    </paper-card>
   {% endfor %}
-  </ul>
+  </div>
 {% endblock %}

--- a/templates/proxy_server.html
+++ b/templates/proxy_server.html
@@ -1,6 +1,7 @@
 {% extends "templates/base.html" %}
 {% block title %}Proxy Server(s){% endblock %}
 {% block head %}
+  <link rel="import" href="/bower_components/iron-collapse/iron-collapse.html" />
   <link rel="import" href="/bower_components/paper-button/paper-button.html" />
   <link rel="import" href="/bower_components/paper-card/paper-card.html" />
 {% endblock %}
@@ -13,9 +14,9 @@
   {% for proxy_server in proxy_servers %}
     <paper-card heading="{{ proxy_server.name }}">
       <div class="card-content">
-        <p>{{ proxy_server.ip_address }},
-        {{ proxy_server.ssh_private_key }},
-        {{ proxy_server.fingerprint }}</p>
+        <p>{{ proxy_server.ip_address }}, {{ proxy_server.fingerprint }}</p>
+        <paper-button onclick="toggleCollapse('collapse-{{loop.index}}')">Show/hide SSH Key</paper-button>
+        <iron-collapse id="collapse-{{loop.index}}"><div>{{ proxy_server.ssh_private_key }}</div></iron-collapse>
       </div>
       <div class="card-actions">
         <a href="{{ BASE_URL }}/proxyserver/edit?id={{ proxy_server.key.id() }}">

--- a/templates/proxy_server_form.html
+++ b/templates/proxy_server_form.html
@@ -1,29 +1,25 @@
 {% extends "templates/base.html" %}
 {% block title %}Proxy Server(s){% endblock %}
+{% block head %}
+  <link rel="import" href="/bower_components/paper-button/paper-button.html" />
+  <link rel="import" href="/bower_components/paper-input/paper-input.html" />
+{% endblock %}
 {% block body %}
   {% if proxy_server %}
-    <form method="post" action="{{ BASE_URL }}/proxyserver/edit">
-      ip address:<br>
-      <input type="text" name="ip_address" value="{{ proxy_server.ip_address }}"><br>
-      name:<br>
-      <input type="text" name="name" value="{{ proxy_server.name }}"><br>
-      ssh private key:<br>
-      <input type="text" name="ssh_private_key" value="{{ proxy_server.ssh_private_key }}"><br>
-      fingerprint:<br>
-      <input type="text" name="fingerprint" value="{{ proxy_server.fingerprint }}">
+    <form id="proxy-edit-add-form" method="post" action="{{ BASE_URL }}/proxyserver/edit">
+      <paper-input label="IP Address" type="text" name="ip_address" value="{{ proxy_server.ip_address }}" required></paper-input>
+      <paper-input label="Name" type="text" name="name" value="{{ proxy_server.name }}" required></paper-input>
+      <paper-input label="SSH Private Key" type="text" name="ssh_private_key" value="{{ proxy_server.ssh_private_key }}" required></paper-input>
+      <paper-input label="Fingerprint" type="text" name="fingerprint" value="{{ proxy_server.fingerprint }}" required></paper-input>
       <input type="hidden" name="id" value="{{ proxy_server.key.id() }}">
   {% else %}
-    <form method="post" action="{{ BASE_URL }}/proxyserver/add">
-      ip address:<br>
-      <input type="text" name="ip_address" value="{{ proxy_server.ip_address }}"><br>
-      name:<br>
-      <input type="text" name="name" value="{{ proxy_server.name }}"><br>
-      ssh private key:<br>
-      <input type="text" name="ssh_private_key" value="{{ proxy_server.ssh_private_key }}"><br>
-      fingerprint:<br>
-      <input type="text" name="fingerprint" value="{{ proxy_server.fingerprint }}">
+    <form id="proxy-edit-add-form" method="post" action="{{ BASE_URL }}/proxyserver/add">
+      <paper-input label="IP Address" type="text" name="ip_address" value="{{ proxy_server.ip_address }}" required></paper-input>
+      <paper-input label="Name" type="text" name="name" value="{{ proxy_server.name }}" required></paper-input>
+      <paper-input label="SSH Private Key" type="text" name="ssh_private_key" value="{{ proxy_server.ssh_private_key }}" required></paper-input>
+      <paper-input label="Fingerprint" type="text" name="fingerprint" value="{{ proxy_server.fingerprint }}" required></paper-input>
   {% endif %}
     <input type="hidden" name="xsrf" value="{{ xsrf_token }}">
-    <input type="submit" value="Submit">
+    <paper-button raised onclick="submitByFormId('proxy-edit-add-form')" class="form-submit-button" type="submit">Submit</paper-button>
   </form>
 {% endblock %}

--- a/templates/setup_client.html
+++ b/templates/setup_client.html
@@ -1,18 +1,16 @@
 {% extends "templates/base.html" %}
 {% block title %}Setup OAuth Client{% endblock %}
+{% block head %}
+  <link rel="import" href="/bower_components/paper-button/paper-button.html" />
+  <link rel="import" href="/bower_components/paper-input/paper-input.html" />
+{% endblock %}
 {% block body %}
-  <form method="post" action="{{ BASE_URL }}/setup/oauthclient">
-    client_id:<br>
-    <input type="text" name="client_id" value="{{ client_id }}">
-    <br>
-    client_secret:<br>
-    <input type="text" name="client_secret" value="{{ client_secret }}">
-    <br>
-    Domain Verification Meta Tag Content:<br>
+  <form id="setup-form" method="post" action="{{ BASE_URL }}/setup/oauthclient">
+    <paper-input label="Client ID" type="text" name="client_id" value="{{ client_id }}" required></paper-input>
+    <paper-input label="Client Secret" type="text" name="client_secret" value="{{ client_secret }}" required></paper-input>
     <p>Please input the text from the content field of a meta tag supplied by Google for domain verification. You can find this data by going to Search Console and clicking on your project, such https://your-project-name-here.appspot.com/. Inside your project, click the gear logo and go to Verification Details. From here, you need to find the HTML tag method of verification. Inside the meta tag is a field called content. Copy everything between the double-quotes for content and paste it into this box. Once you've submitted this form, you can go back to your project in appspot and click Verify to complete verification.</p>
-    <input type="text" name="dv_content" value="{{ dv_content }}">
-    <br><br>
+    <paper-input label="Domain Verification Meta Tag Content" type="text" name="dv_content" value="{{ dv_content }}" required></paper-input>
     <input type="hidden" name="xsrf" value="{{ xsrf_token }}">
-    <input type="submit" value="Submit">
+    <paper-button raised onclick="submitByFormId('setup-form')" class="form-submit-button" type="submit">Submit</paper-button>
   </form>
 {% endblock %}

--- a/templates/token.html
+++ b/templates/token.html
@@ -1,16 +1,23 @@
 {% extends "templates/base.html" %}
 {% block title %}Tokens{% endblock %}
+{% block head %}
+  <link rel="import" href="/bower_components/paper-button/paper-button.html" />
+  <link rel="import" href="/bower_components/paper-item/paper-item.html" />
+  <link rel="import" href="/bower_components/paper-listbox/paper-listbox.html" />
+{% endblock %}
 {% block body %}
-  <ul>
+  <paper-listbox>
   {% for key, (email, token_payload) in user_token_payloads.iteritems() %}
-    <li>
+    <paper-item>
       <b>{{ email }}</b>
-      <a href="{{ BASE_URL }}/user/getNewToken?key={{ key }}">(Get New Token)</a>
-      <br />
+      <a href="{{ BASE_URL }}/user/getNewToken?key={{ key }}">
+        <paper-button raised class="anchor-button">Get New Token
+        </paper-button></a>
+    </paper-item>
+    <paper-item>
       token_payload: {{ token_payload }} &nbsp;&nbsp;&nbsp;
-      <br />
-    </li>
+    </paper-item>
     <br />
   {% endfor %}
-  </ul>
+  </paper-listbox>
 {% endblock %}

--- a/templates/user.html
+++ b/templates/user.html
@@ -2,20 +2,23 @@
 {% block title %}Users{% endblock %}
 {% block head %}
   <link rel="import" href="/bower_components/paper-button/paper-button.html" />
+  <link rel="import" href="/bower_components/paper-card/paper-card.html" />
   <link rel="import" href="/bower_components/paper-item/paper-item.html" />
   <link rel="import" href="/bower_components/paper-listbox/paper-listbox.html" />
 {% endblock %}
 {% block body %}
-  <a href="{{ BASE_URL }}/user/add">
-    <paper-button raised class="anchor-button">Add Users</paper-button></a>
-  <a href="{{ BASE_URL }}/user/listTokens">
-    <paper-button raised class="anchor-button">List Tokens</paper-button></a>
-    <br />
-  {% if invite_code %}
-    <h4>Invite Code Below</h4>
-    <textarea rows="20" cols="80">{{ invite_code }}</textarea><br>
-  {% endif %}
-  <paper-listbox>
+  <div class="top-buttons">
+    <a href="{{ BASE_URL }}/user/add">
+      <paper-button raised class="anchor-button">Add Users</paper-button></a>
+    <a href="{{ BASE_URL }}/user/listTokens">
+      <paper-button raised class="anchor-button">List Tokens</paper-button></a>
+      <br />
+    {% if invite_code %}
+      <h4>Invite Code Below</h4>
+      <textarea rows="20" cols="80">{{ invite_code }}</textarea><br>
+    {% endif %}
+  </div>
+  <paper-card heading="Users"><paper-listbox>
   {% for key, email in user_payloads.iteritems() %}
     <paper-item>{{ email }}
       <a href="{{ BASE_URL }}/user/delete?key={{ key }}">
@@ -30,5 +33,5 @@
     </paper-item>
     <br />
   {% endfor %}
-  </paper-listbox>
+  </paper-listbox></paper-card>
 {% endblock %}

--- a/templates/user.html
+++ b/templates/user.html
@@ -1,23 +1,34 @@
 {% extends "templates/base.html" %}
 {% block title %}Users{% endblock %}
+{% block head %}
+  <link rel="import" href="/bower_components/paper-button/paper-button.html" />
+  <link rel="import" href="/bower_components/paper-item/paper-item.html" />
+  <link rel="import" href="/bower_components/paper-listbox/paper-listbox.html" />
+{% endblock %}
 {% block body %}
-  <a href="{{ BASE_URL }}/user/add">Add Users</a><br />
-  <a href="{{ BASE_URL }}/user/listTokens">List Tokens</a><br />
+  <a href="{{ BASE_URL }}/user/add">
+    <paper-button raised class="anchor-button">Add Users</paper-button></a>
+  <a href="{{ BASE_URL }}/user/listTokens">
+    <paper-button raised class="anchor-button">List Tokens</paper-button></a>
+    <br />
   {% if invite_code %}
     <h4>Invite Code Below</h4>
     <textarea rows="20" cols="80">{{ invite_code }}</textarea><br>
   {% endif %}
-  <ul>
+  <paper-listbox>
   {% for key, email in user_payloads.iteritems() %}
-    <li>{{ email }}
-      <a href="{{ BASE_URL }}/user/delete?key={{ key }}">(Delete User)</a>
+    <paper-item>{{ email }}
+      <a href="{{ BASE_URL }}/user/delete?key={{ key }}">
+        <paper-button raised class="anchor-button">Delete User
+      </paper-button></a>
       <a href="{{ BASE_URL }}/user/getInviteCode?key={{ key }}">
-        (Get Invite Code)</a>
-      <br />
+        <paper-button raised class="anchor-button">Get Invite Code
+      </paper-button></a>
       <a href="{{ BASE_URL }}/user/getNewToken?key={{ key }}">
-        (Get New Token)</a>
-    </li>
+        <paper-button raised class="anchor-button">Get New Token
+      </paper-button></a>
+    </paper-item>
     <br />
   {% endfor %}
-  </ul>
+  </paper-listbox>
 {% endblock %}

--- a/tests/ui/user_page_test.py
+++ b/tests/ui/user_page_test.py
@@ -9,18 +9,18 @@ from selenium import webdriver
 class UserPageTest(unittest.TestCase):
 
   def setUp(self):
-  self.driver = webdriver.Chrome('../../chromedriver')
-  DevServerLoginPage(self.driver).Login()
+    self.driver = webdriver.Chrome('../../chromedriver')
+    DevServerLoginPage(self.driver).Login()
 
   def testUserPage(self):
     add_users = 'Add Users'
     list_tokens = 'List Tokens'
 
     self.driver.get('http://localhost:9999/user')
-  user_page = UserPage(self.driver)
-  self.assertEquals(add_users, user_page.GetAddUserLink().text)
-  self.assertEquals(list_tokens, user_page.GetListTokensLink().text)
-  self.assertIsNotNone(user_page.GetSidebar())
+    user_page = UserPage(self.driver)
+    self.assertEquals(add_users, user_page.GetAddUserLink().text)
+    self.assertEquals(list_tokens, user_page.GetListTokensLink().text)
+    self.assertIsNotNone(user_page.GetSidebar())
 
   def tearDown(self):
     self.driver.quit()


### PR DESCRIPTION
This does not swap forms for polymer iron forms. Unfortunately, iron forms operate on AJAX rather than standard HTML form controls for submissions, and so, they don't handle responses at all (which also applies to redirects). If we want to use those, we'll have to write a lot of boilerplate Javascript to get the actual response and direct the user as appropriate. Seems like more work than necessary for now, but it is nice to know that we can use AJAX forms with this where no response is required.

Also, this does not swap input checkboxes for paper-checkboxes. When submitting a form, paper-checkboxes are not recognized as inputs, so the default form behavior does not collect them to submit. This may be alleviated by switching to iron forms (as the demo for iron forms makes use of them successfully). If not, then we would have to write more boilerplate Javascript to collect these values into an array and submit them with the form.

Hopefully future releases of the checkbox will fix this, but I doubt the iron form will change anytime soon. It sucks that these are not just plug and play (so to speak) which is the entire model Polymer is hoping to achieve.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server/40)
<!-- Reviewable:end -->
