### PR TITLE
Giant Lint Issue Fix

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -1,0 +1,4 @@
+doc-warnings: yes
+test-warnings: no
+strictness: veryhigh
+max-line-length: 80

--- a/.pylintrc
+++ b/.pylintrc
@@ -8,3 +8,9 @@
 # String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
 # tab). We use two spaces however.
 indent-string='  '
+
+# Capwords setting for methods and allow get and post for request overloading.
+method-rgx=([A-Z_][a-zA-Z0-9]{2,30}|get|post)$
+
+# Capwords setting with exception for decorate for functions.
+function-rgx=([A-Z_][a-zA-Z0-9_]{2,30}|decorate)$

--- a/admin.py
+++ b/admin.py
@@ -5,9 +5,8 @@ import logging
 from google.appengine.api import users
 
 
-def require_admin(func):
+def RequireAdmin(func):
   """Decorator to require the user to be an admin."""
-
   def decorate(self, *args, **kwargs):
     """Actual decorate function that requires admin.
 
@@ -15,7 +14,6 @@ def require_admin(func):
       args: Parameters passed on to the specified function if successful.
       kwargs: Parameters passed on to the specified function if successful.
     """
-
     user = users.get_current_user()
     if not user:
       logging.error('user is not logged in')

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -16,7 +16,7 @@ JINJA_ENVIRONMENT = jinja2.Environment(
     autoescape=True)
 
 
-JINJA_ENVIRONMENT.globals['xsrf_token'] = xsrf.xsrf_token()
+JINJA_ENVIRONMENT.globals['xsrf_token'] = xsrf.XSRFToken()
 HOST = str(app_identity.get_default_version_hostname())
 JINJA_ENVIRONMENT.globals['BASE_URL'] = ('https://' + HOST)
 

--- a/datastore.py
+++ b/datastore.py
@@ -13,6 +13,7 @@ from google.appengine.ext import ndb
 
 
 class BaseModel(ndb.Model):
+
   """Base model that provides generic methods for inheriting classes."""
 
   @classmethod
@@ -26,8 +27,8 @@ class BaseModel(ndb.Model):
     Returns:
       An integer of all the entities in the datastore.
     """
-    q = cls.query()
-    return q.count()
+    query = cls.query()
+    return query.count()
 
   @classmethod
   def GetAll(cls):
@@ -40,8 +41,8 @@ class BaseModel(ndb.Model):
     Returns:
       A list of datastore entities.
     """
-    q = cls.query()
-    return q.fetch()
+    query = cls.query()
+    return query.fetch()
 
   @classmethod
   def Get(cls, entity_id):
@@ -100,6 +101,7 @@ class BaseModel(ndb.Model):
 
 
 class User(BaseModel):
+
   """Datastore service to handle dasher users."""
 
   email = ndb.StringProperty()
@@ -184,6 +186,7 @@ class User(BaseModel):
 
 
 class ProxyServer(BaseModel):
+
   """Store data related to the proxy servers."""
 
   ip_address = ndb.StringProperty()
@@ -201,7 +204,6 @@ class ProxyServer(BaseModel):
       ssh_private_key: What to set the proxy server's ssh_private_key field to.
       fingerprint: What to set the proxy server's fingerprint field to.
     """
-
     entity = ProxyServer(name=name,
                          ip_address=ip_address,
                          ssh_private_key=ssh_private_key,
@@ -220,7 +222,6 @@ class ProxyServer(BaseModel):
       ssh_private_key: What to set the proxy server's ssh_private_key field to.
       fingerprint: What to set the proxy server's fingerprint field to.
     """
-
     entity = ProxyServer.Get(entity_id)
     entity.name = name
     entity.ip_address = ip_address
@@ -230,12 +231,14 @@ class ProxyServer(BaseModel):
 
 
 class OAuth(BaseModel):
+
   """Store the client secret so that it's not checked into source code.
 
   Secret is accessible at:
   https://console.developers.google.com/project
   Set the secret using the Datastore Viewer at https://appengine.google.com
   """
+
   # The comment below disables landscape.io checking on that line so that it
   # does not think we have an actual secret stored which we do not. The
   # object it is used to get has a parameter which is the actual secret. This
@@ -260,7 +263,6 @@ class OAuth(BaseModel):
     Returns:
       The datastore entity for OAuth.
     """
-
     entity = OAuth.Get(OAuth.CLIENT_SECRET_ID)
     if not entity:
       OAuth.InsertDefault()
@@ -270,7 +272,6 @@ class OAuth(BaseModel):
   @staticmethod
   def InsertDefault():
     """Insert entity with default client id and secret into the datastore."""
-
     OAuth.Insert(new_client_id=OAuth.DEFAULT_ID,
                  new_client_secret=OAuth.DEFAULT_SECRET)
 
@@ -298,7 +299,6 @@ class OAuth(BaseModel):
       new_client_id: The client id value to set on the OAuth entity.
       new_client_secret: The client secret value to set on the OAuth entity.
     """
-
     entity = OAuth.Get(OAuth.CLIENT_SECRET_ID)
     entity.client_id = new_client_id
     entity.client_secret = new_client_secret
@@ -307,16 +307,17 @@ class OAuth(BaseModel):
   @staticmethod
   def Flush():
     """Flush the memcache for OAuth."""
-
     # Make sure to update the memcache
     memcache.flush_all()
 
 class DomainVerification(BaseModel):
+
   """Store the domain verification content.
 
   This is for accessing push notifications so that any admin's actual domain
   verification content is not checked into source code.
   """
+
   CONTENT_ID = 'my_domain_verification_content'
   DEFAULT_CONTENT = 'Change me to the real domain verification content.'
 
@@ -332,7 +333,6 @@ class DomainVerification(BaseModel):
     Returns:
       The datastore entity for DomainVerification.
     """
-
     entity = DomainVerification.Get(DomainVerification.CONTENT_ID)
     if not entity:
       DomainVerification.InsertDefault()
@@ -342,7 +342,6 @@ class DomainVerification(BaseModel):
   @staticmethod
   def InsertDefault():
     """Insert the DV entity with default content into the datastore."""
-
     DomainVerification.Insert(DomainVerification.DEFAULT_CONTENT)
 
   @staticmethod
@@ -355,7 +354,6 @@ class DomainVerification(BaseModel):
     Args:
       new_content: The content value to set on the DomainVerification entity.
     """
-
     entity = DomainVerification(id=DomainVerification.CONTENT_ID,
                                 content=new_content)
     entity.put()
@@ -367,7 +365,6 @@ class DomainVerification(BaseModel):
     Args:
       new_content: The content value to set on the DomainVerification entity.
     """
-
     entity = DomainVerification.Get(DomainVerification.CONTENT_ID)
     entity.content = new_content
     entity.put()

--- a/error_handlers.py
+++ b/error_handlers.py
@@ -14,7 +14,6 @@ def Handle500(request, response, exception):
     response: The response object to write to or redirect on.
     exception: The specific exception caused by the request.
   """
-
   if (isinstance(exception, FlowExchangeError)
       and exception.message == 'invalid_client'):
     response.write('Setup your client_secret in the datastore.')

--- a/google_directory_service.py
+++ b/google_directory_service.py
@@ -10,9 +10,11 @@ NUM_RETRIES = 3
 # TODO(eholder): Write tests for these functions.
 
 class GoogleDirectoryService(object):
+
   """Interact with Google Directory API."""
 
   def __init__(self, oauth_decorator):
+    """Create a service object for admin directory services using oauth."""
     self.service = build(serviceName='admin',
                          version='directory_v1',
                          http=oauth_decorator.http())

--- a/logout.py
+++ b/logout.py
@@ -7,16 +7,17 @@ import webapp2
 LOG_BACK_IN_PATH = '/user'
 
 class LogoutHandler(webapp2.RequestHandler):
+
   """Logs the current user out."""
+
 	# pylint: disable=too-few-public-methods
 
   def get(self):
     """Log the user out and point the login address to the default path."""
-
     logout_url = users.create_logout_url(LOG_BACK_IN_PATH)
     self.redirect(logout_url)
 
 
-app = webapp2.WSGIApplication([
+APP = webapp2.WSGIApplication([
     ('/logout', LogoutHandler),
 ], debug=True)

--- a/logout_test.py
+++ b/logout_test.py
@@ -14,7 +14,7 @@ import logout
 class LogoutTest(unittest.TestCase):
 
   def setUp(self):
-    self.testapp = webtest.TestApp(logout.app)
+    self.testapp = webtest.TestApp(logout.APP)
 
   @patch('google.appengine.api.users.create_logout_url')
   def testLogoutHandler(self, mock_create_url):
@@ -23,7 +23,7 @@ class LogoutTest(unittest.TestCase):
     mock_create_url.return_value = fake_redirect_url
 
     response = self.testapp.get(logout_relative_path)
-    
+
     mock_create_url.assert_called_once_with(logout.LOG_BACK_IN_PATH)
     self.assertEqual(response.status_int, 302)
     self.assertTrue(fake_redirect_url in response.location)

--- a/proxy_server.py
+++ b/proxy_server.py
@@ -35,12 +35,13 @@ def _RenderListProxyServerTemplate():
 
 def _MakeKeyString():
   """Generate the key string in open ssh format for pushing to proxy servers.
-     This key string includes only the public key for each user in order to
-     grant the user access to each proxy server.
 
-    Returns:
-      key_string: A string of users with associated key.
-    """
+  This key string includes only the public key for each user in order to grant
+  the user access to each proxy server.
+
+  Returns:
+    key_string: A string of users with associated key.
+  """
   users = User.GetAll()
   key_string = ''
   ssh_starting_portion = 'ssh-rsa'
@@ -55,16 +56,16 @@ def _MakeKeyString():
 
 
 class AddProxyServerHandler(webapp2.RequestHandler):
+
   """Handler for adding new proxy servers."""
 
-  @admin.require_admin
+  @admin.RequireAdmin
   def get(self):
     """Get the form for adding new proxy servers."""
-
     self.response.write(_RenderProxyServerFormTemplate(None))
 
-  @admin.require_admin
-  @xsrf.xsrf_protect
+  @admin.RequireAdmin
+  @xsrf.XSRFProtect
   def post(self):
     """Add a new proxy server with the post parameters passed in."""
     ProxyServer.Insert(
@@ -76,16 +77,17 @@ class AddProxyServerHandler(webapp2.RequestHandler):
 
 
 class EditProxyServerHandler(webapp2.RequestHandler):
+
   """Handler for editing an existing proxy server."""
 
-  @admin.require_admin
+  @admin.RequireAdmin
   def get(self):
     """Get a proxy server's current data and display its edit form."""
     proxy_server = ProxyServer.Get(int(self.request.get('id')))
     self.response.write(_RenderProxyServerFormTemplate(proxy_server))
 
-  @admin.require_admin
-  @xsrf.xsrf_protect
+  @admin.RequireAdmin
+  @xsrf.XSRFProtect
   def post(self):
     """Set an existing proxy server with the post parameters passed in."""
     ProxyServer.Update(
@@ -98,10 +100,12 @@ class EditProxyServerHandler(webapp2.RequestHandler):
 
 
 class DeleteProxyServerHandler(webapp2.RequestHandler):
+
   """Handler for deleting an existing proxy server."""
+
   # pylint: disable=too-few-public-methods
 
-  @admin.require_admin
+  @admin.RequireAdmin
   def get(self):
     """Delete the proxy server corresponding to the passed in id.
 
@@ -112,17 +116,21 @@ class DeleteProxyServerHandler(webapp2.RequestHandler):
 
 
 class ListProxyServersHandler(webapp2.RequestHandler):
+
   """Handler for listing all existing proxy servers."""
+
   # pylint: disable=too-few-public-methods
 
-  @admin.require_admin
+  @admin.RequireAdmin
   def get(self):
     """Get all current proxy servers and list them with their metadata."""
     self.response.write(_RenderListProxyServerTemplate())
 
 
 class DistributeKeyHandler(webapp2.RequestHandler):
+
   """Handler for distributing authorization keys out to each proxy server."""
+
   # pylint: disable=too-few-public-methods
 
   # This handler requires admin login, and is controlled in the app.yaml.
@@ -151,7 +159,7 @@ class DistributeKeyHandler(webapp2.RequestHandler):
     self.response.write('all done!')
 
 
-app = webapp2.WSGIApplication([
+APP = webapp2.WSGIApplication([
     ('/proxyserver/add', AddProxyServerHandler),
     ('/proxyserver/delete', DeleteProxyServerHandler),
     ('/proxyserver/edit', EditProxyServerHandler),

--- a/proxy_server.py
+++ b/proxy_server.py
@@ -17,7 +17,6 @@ def _RenderProxyServerFormTemplate(proxy_server):
   """Render the form to add or edit a proxy server."""
   template_values = {
       'proxy_server': proxy_server,
-      'xsrf_token': xsrf.xsrf_token(),
   }
   template = JINJA_ENVIRONMENT.get_template('templates/proxy_server_form.html')
   return template.render(template_values)

--- a/proxy_server_test.py
+++ b/proxy_server_test.py
@@ -14,11 +14,11 @@ def noop_decorator(func):
   return func
 
 mock_admin = MagicMock()
-mock_admin.require_admin = noop_decorator
+mock_admin.RequireAdmin = noop_decorator
 sys.modules['admin'] = mock_admin
 
 mock_xsrf = MagicMock()
-mock_xsrf.xsrf_protect = noop_decorator
+mock_xsrf.XSRFProtect = noop_decorator
 sys.modules['xsrf'] = mock_xsrf
 
 
@@ -34,7 +34,7 @@ FAKE_FINGERPRINT = '11:22:33:44'
 class ProxyServerTest(unittest.TestCase):
 
   def setUp(self):
-    self.testapp = webtest.TestApp(proxy_server.app)
+    self.testapp = webtest.TestApp(proxy_server.APP)
 
   @patch('proxy_server._RenderListProxyServerTemplate')
   def testListProxyServersHandler(self, mock_render_list_template):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from datastore import User
 from datastore import OAuth
 from datastore import DomainVerification
 from error_handlers import Handle500
-import json
 import webapp2
 import xsrf
 import admin
@@ -28,15 +27,18 @@ def _RenderSetupOAuthClientTemplate():
 
 
 class SetupOAuthClientHandler(webapp2.RequestHandler):
+
   """Setup a client in the datastore."""
 
-  @admin.require_admin
+  @admin.RequireAdmin
   def get(self):
+    """Output the oauth and domain verification template."""
     self.response.write(_RenderSetupOAuthClientTemplate())
 
-  @admin.require_admin
-  @xsrf.xsrf_protect
+  @admin.RequireAdmin
+  @xsrf.XSRFProtect
   def post(self):
+    """Store client id, client secret, and domain verification content."""
     client_id = self.request.get('client_id')
     client_secret = self.request.get('client_secret')
     OAuth.Update(client_id, client_secret)
@@ -49,10 +51,10 @@ class SetupOAuthClientHandler(webapp2.RequestHandler):
       self.redirect('/user/add')
 
 
-app = webapp2.WSGIApplication([
+APP = webapp2.WSGIApplication([
     ('/setup/oauthclient', SetupOAuthClientHandler),
     (OAUTH_DECORATOR.callback_path, OAUTH_DECORATOR.callback_handler()),
 ], debug=True)
 
 # This is the only way to catch exceptions from the oauth decorators.
-app.error_handlers[500] = Handle500
+APP.error_handlers[500] = Handle500

--- a/setup_test.py
+++ b/setup_test.py
@@ -20,11 +20,11 @@ mock_auth.OAUTH_DECORATOR.oauth_required = noop_decorator
 sys.modules['auth'] = mock_auth
 
 mock_xsrf = MagicMock()
-mock_xsrf.xsrf_protect = noop_decorator
+mock_xsrf.XSRFProtect = noop_decorator
 sys.modules['xsrf'] = mock_xsrf
 
 mock_admin = MagicMock()
-mock_admin.require_admin = noop_decorator
+mock_admin.RequireAdmin = noop_decorator
 sys.modules['admin'] = mock_admin
 
 
@@ -40,7 +40,7 @@ FAKE_CONTENT = 'foobar'
 class SetupTest(unittest.TestCase):
 
   def setUp(self):
-    self.testapp = webtest.TestApp(setup.app)
+    self.testapp = webtest.TestApp(setup.APP)
 
   @patch('setup._RenderSetupOAuthClientTemplate')
   def testSetupOAuthClientGetHandler(self, mock_render_oauth_template):

--- a/user.py
+++ b/user.py
@@ -21,17 +21,18 @@ import xsrf
 
 def _GenerateTokenPayload(users):
   """Generate the token payload data for all users and their public keys.
-    I could just pass through all the user's properties here, but that
-    would expose the private key we have in the datastore along with
-    various other user data, so I'm explicitly limiting what we show to
-    an email and public key pair along with the datastore key.
 
-    Args:
-      users: A list of users with associated properties from the datastore.
+  I could just pass through all the user's properties here, but that
+  would expose the private key we have in the datastore along with
+  various other user data, so I'm explicitly limiting what we show to
+  an email and public key pair along with the datastore key.
 
-    Returns:
-      user_token_payloads: A dictionary with user key id as key, and a token
-          and email tuple as a value.
+  Args:
+    users: A list of users with associated properties from the datastore.
+
+  Returns:
+    user_token_payloads: A dictionary with user key id as key, and a token
+        and email tuple as a value.
   """
   user_token_payloads = {}
   for user in users:
@@ -43,17 +44,18 @@ def _GenerateTokenPayload(users):
 
 def _GenerateUserPayload(users):
   """Generate the user payload data for all users.
-    I could just pass through all the user's properties here, but that
-    would expose the private key we have in the datastore along with
-    various other user data, so I'm explicitly limiting what we show to
-    an email and key for modifying values.
 
-    Args:
-      users: A list of users with associated properties from the datastore.
+  I could just pass through all the user's properties here, but that
+  would expose the private key we have in the datastore along with
+  various other user data, so I'm explicitly limiting what we show to
+  an email and key for modifying values.
 
-    Returns:
-      user_token_payloads: A dictionary with user key id as key and email
-          as a value.
+  Args:
+    users: A list of users with associated properties from the datastore.
+
+  Returns:
+    user_token_payloads: A dictionary with user key id as key and email
+        as a value.
   """
   user_token_payloads = {}
   for user in users:
@@ -63,7 +65,7 @@ def _GenerateUserPayload(users):
 
 
 def _MakeInviteCode(user):
-  """Create an invite code for the given user.
+  r"""Create an invite code for the given user.
 
   The invite code is a format created by the uproxy team.
   Below is an example of an unencoded invite code for a cloud instance:
@@ -107,7 +109,7 @@ def _MakeInviteCode(user):
 
 
 def _GetInviteCodeIp():
-  """Gets the ip address for placing in the invite code.
+  """Get the ip address for placing in the invite code.
 
   Eventually this method will actually get the load balancer's ip as we will
   want in the final version. For now, it is used as a simple stub to just pick
@@ -167,7 +169,9 @@ def _RenderAddUsersTemplate(directory_users, error=None):
 
 
 class LandingPageHandler(webapp2.RequestHandler):
+
   """Display the landing page which doesn't require oauth."""
+
   # pylint: disable=too-few-public-methods
 
   def get(self):
@@ -176,7 +180,9 @@ class LandingPageHandler(webapp2.RequestHandler):
 
 
 class ListUsersHandler(webapp2.RequestHandler):
+
   """List the current users."""
+
   # pylint: disable=too-few-public-methods
 
   @OAUTH_DECORATOR.oauth_required
@@ -186,7 +192,9 @@ class ListUsersHandler(webapp2.RequestHandler):
 
 
 class DeleteUserHandler(webapp2.RequestHandler):
+
   """Delete a given user."""
+
   # pylint: disable=too-few-public-methods
 
   @OAUTH_DECORATOR.oauth_required
@@ -201,7 +209,9 @@ class DeleteUserHandler(webapp2.RequestHandler):
 
 
 class ListTokensHandler(webapp2.RequestHandler):
+
   """List the tokens and associated users."""
+
   # pylint: disable=too-few-public-methods
 
   @OAUTH_DECORATOR.oauth_required
@@ -211,7 +221,9 @@ class ListTokensHandler(webapp2.RequestHandler):
 
 
 class GetInviteCodeHandler(webapp2.RequestHandler):
+
   """Get an invite code for a given user."""
+
   # pylint: disable=too-few-public-methods
 
   @OAUTH_DECORATOR.oauth_required
@@ -225,7 +237,9 @@ class GetInviteCodeHandler(webapp2.RequestHandler):
 
 
 class GetNewTokenHandler(webapp2.RequestHandler):
+
   """Create a new token for a given user."""
+
   # pylint: disable=too-few-public-methods
 
   @OAUTH_DECORATOR.oauth_required
@@ -238,9 +252,10 @@ class GetNewTokenHandler(webapp2.RequestHandler):
 
 
 class AddUsersHandler(webapp2.RequestHandler):
+
   """Add users into the datastore."""
 
-  @admin.require_admin
+  @admin.RequireAdmin
   @OAUTH_DECORATOR.oauth_required
   def get(self):
     """Get the form for adding new users.
@@ -272,8 +287,8 @@ class AddUsersHandler(webapp2.RequestHandler):
     except errors.HttpError as error:
       self.response.write(_RenderAddUsersTemplate([], error))
 
-  @admin.require_admin
-  @xsrf.xsrf_protect
+  @admin.RequireAdmin
+  @xsrf.XSRFProtect
   @OAUTH_DECORATOR.oauth_required
   def post(self):
     """Add all of the selected users into the datastore."""
@@ -286,7 +301,7 @@ class AddUsersHandler(webapp2.RequestHandler):
     self.redirect('/user')
 
 
-app = webapp2.WSGIApplication([
+APP = webapp2.WSGIApplication([
     ('/', LandingPageHandler),
     ('/user', ListUsersHandler),
     ('/user/delete', DeleteUserHandler),
@@ -298,4 +313,4 @@ app = webapp2.WSGIApplication([
 ], debug=True)
 
 # This is the only way to catch exceptions from the oauth decorators.
-app.error_handlers[500] = Handle500
+APP.error_handlers[500] = Handle500

--- a/user_test.py
+++ b/user_test.py
@@ -24,11 +24,11 @@ mock_auth.OAUTH_DECORATOR.oauth_required = noop_decorator
 sys.modules['auth'] = mock_auth
 
 mock_xsrf = MagicMock()
-mock_xsrf.xsrf_protect = noop_decorator
+mock_xsrf.XSRFProtect = noop_decorator
 sys.modules['xsrf'] = mock_xsrf
 
 mock_admin = MagicMock()
-mock_admin.require_admin = noop_decorator
+mock_admin.RequireAdmin = noop_decorator
 sys.modules['admin'] = mock_admin
 
 import user
@@ -59,7 +59,7 @@ FAKE_USER_ARRAY.append(FAKE_ADD_USER)
 class UserTest(unittest.TestCase):
 
   def setUp(self):
-    self.testapp = webtest.TestApp(user.app)
+    self.testapp = webtest.TestApp(user.APP)
 
   @patch('user._RenderLandingTemplate')
   def testListUsersHandler(self, mock_landing_template):

--- a/xsrf.py
+++ b/xsrf.py
@@ -16,14 +16,14 @@ from google.appengine.api import users
 from google.appengine.ext import ndb
 
 
-def xsrf_token():
+def XSRFToken():
   """Generate a new xsrf secret and output it in urlsafe base64 encoding."""
   digester = hmac.new(str(XsrfSecret.get()))
   digester.update(str(users.get_current_user().user_id()))
   return base64.urlsafe_b64encode(digester.digest())
 
 
-def xsrf_protect(func):
+def XSRFProtect(func):
   """Decorator to require valid XSRF token."""
   def decorate(self, *args, **kwargs):
     """Actual decorate function that requires a valid XSRF token.
@@ -36,7 +36,7 @@ def xsrf_protect(func):
     if not token:
       logging.error('xsrf token not included')
       self.abort(403)
-    if not const_time_compare(token, xsrf_token()):
+    if not ConstTimeCompare(token, xsrf_token()):
       logging.error('xsrf token does not validate')
       self.abort(403)
     return func(self, *args, **kwargs)
@@ -44,26 +44,28 @@ def xsrf_protect(func):
   return decorate
 
 
-def const_time_compare(a, b):
-  """Compares the the given strings in constant time."""
-  if len(a) != len(b):
+def ConstTimeCompare(string_a, string_b):
+  """Compare the the given strings in constant time."""
+  if len(string_a) != len(string_b):
     return False
 
   equals = 0
-  for x, y in zip(a, b):
-    equals |= ord(x) ^ ord(y)
+  for char_x, char_y in zip(string_a, string_b):
+    equals |= ord(char_x) ^ ord(char_y)
 
   return equals == 0
 
 
 class XsrfSecret(ndb.Model):
+
   """Model for datastore to store the XSRF secret."""
+
   # pylint: disable=too-few-public-methods
   secret = ndb.StringProperty(required=True)
 
   @staticmethod
   def get():
-    """Retrieves the XSRF secret.
+    """Retrieve the XSRF secret.
 
     Tries to retrieve the XSRF secret from memcache, and if that fails, falls
     back to getting it out of datastore. Note that the secret should not be

--- a/xsrf.py
+++ b/xsrf.py
@@ -36,7 +36,7 @@ def XSRFProtect(func):
     if not token:
       logging.error('xsrf token not included')
       self.abort(403)
-    if not ConstTimeCompare(token, xsrf_token()):
+    if not ConstTimeCompare(token, XSRFToken()):
       logging.error('xsrf token does not validate')
       self.abort(403)
     return func(self, *args, **kwargs)


### PR DESCRIPTION
This updates our pylintrc file to match the CapWords naming convention we use. Now it correctly identifies real errors when we encounter them. I also upped the setting on landscape to very high so that it displays basically every error it encounters. It is not checking tests right now, which we can enable later if we choose. There is also an exception in the method and function naming conventions for get, post, and decorate as those are names that seem to require lower case rather than CamelCase.

As a result of these improvements to our checking, I've now gone back and fixed numerous lint errors related to naming convention, indentation, spacing, and imports. Nothing should be functionally different than it was before, but now we should be able to clearly see what errors are real or not when running landscape and use that as a reliable metric.

After the latest push, Landscape reports 11 total messages, which is down from the 300 or so when we first started using it. Of those 11, 4 are errors related to its inability to understand our use of appengine. It does not believe that the query function exists on classes interacting with the datastore. The other 7 messages are what it calls "code smells", which happen to be TODO comments left in the code. Those should improve over time as we implement more and more functionality and testing.

Sorry for the large change, but it should be straightforward to just check that things now follow the correct convention.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server/44)
<!-- Reviewable:end -->
