### PR TITLE
User Page and Fixed Sidebar Links

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -27,3 +27,7 @@ paper-card {
 #proxy-card-holder {
   max-width: 800px;
 }
+
+#user-card-holder {
+  max-width: 600px;
+}

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ class SetupOAuthClientHandler(webapp2.RequestHandler):
 
 
 APP = webapp2.WSGIApplication([
-    ('/setup/oauthclient', SetupOAuthClientHandler),
+    ('/setup', SetupOAuthClientHandler),
     (OAUTH_DECORATOR.callback_path, OAUTH_DECORATOR.callback_handler()),
 ], debug=True)
 

--- a/setup_test.py
+++ b/setup_test.py
@@ -44,7 +44,7 @@ class SetupTest(unittest.TestCase):
 
   @patch('setup._RenderSetupOAuthClientTemplate')
   def testSetupOAuthClientGetHandler(self, mock_render_oauth_template):
-    self.testapp.get('/setup/oauthclient')
+    self.testapp.get('/setup')
     mock_render_oauth_template.assert_called_once_with()
 
   @patch('user.User.GetCount')
@@ -56,7 +56,7 @@ class SetupTest(unittest.TestCase):
                                                 mock_dv_update,
                                                 mock_get_count):
     mock_get_count.return_value = 1
-    post_url = ('/setup/oauthclient?client_id={0}&client_secret={1}' +
+    post_url = ('/setup?client_id={0}&client_secret={1}' +
                 '&dv_content={2}')
     resp = self.testapp.post(post_url.format(unicode(FAKE_ID,'utf-8'),
                                              unicode(FAKE_SECRET,'utf-8'),
@@ -77,7 +77,7 @@ class SetupTest(unittest.TestCase):
                                             mock_dv_update,
                                             mock_get_count):
     mock_get_count.return_value = 0
-    post_url = ('/setup/oauthclient?client_id={0}&client_secret={1}' +
+    post_url = ('/setup?client_id={0}&client_secret={1}' +
                 '&dv_content={2}')
     resp = self.testapp.post(post_url.format(unicode(FAKE_ID,'utf-8'),
                                              unicode(FAKE_SECRET,'utf-8'),

--- a/static/sidebar.js
+++ b/static/sidebar.js
@@ -5,7 +5,7 @@ Polymer({
     {"href": "/", "text": "Home"},
     {"href": "/user", "text": "Users"},
     {"href": "/proxyserver/list", "text": "Proxy Servers"},
-    {"href": "/setup/oauthclient", "text": "Setup"},
+    {"href": "/setup", "text": "Setup"},
     {"href": "/logout", "text": "Logout"}
     ];
   },

--- a/static/sidebar.js
+++ b/static/sidebar.js
@@ -4,7 +4,6 @@ Polymer({
     this.pages = [
     {"href": "/", "text": "Home"},
     {"href": "/user", "text": "Users"},
-    {"href": "/user/listTokens", "text": "Tokens"},
     {"href": "/proxyserver/list", "text": "Proxy Servers"},
     {"href": "/setup/oauthclient", "text": "Setup"},
     {"href": "/logout", "text": "Logout"}

--- a/templates/proxy_server.html
+++ b/templates/proxy_server.html
@@ -10,7 +10,7 @@
     <paper-button raised class="anchor-button">Add New Proxy Server
     </paper-button></a>
   <p>Name, IP Address, Private Key, Fingerprint</p>
-  <div id="proxy-card-holder"/>
+  <div id="proxy-card-holder">
   {% for proxy_server in proxy_servers %}
     <paper-card heading="{{ proxy_server.name }}">
       <div class="card-content">

--- a/templates/user.html
+++ b/templates/user.html
@@ -10,31 +10,16 @@
   <div class="top-buttons">
     <a id='add_users' href="{{ BASE_URL }}/user/add">
       <paper-button raised class="anchor-button">Add Users</paper-button></a>
-    <a id='list_tokens' href="{{ BASE_URL }}/user/listTokens">
-      <paper-button raised class="anchor-button">List Tokens</paper-button></a>
       <br />
-    {% if invite_code %}
-      <h4>Invite Code Below</h4>
-      <textarea rows="20" cols="80">{{ invite_code }}</textarea><br>
-    {% endif %}
   </div>
-  <paper-card heading="Users"><paper-listbox>
-  {% for key, email in user_payloads.iteritems() %}
-    <paper-item>{{ email }}
-      <a href="{{ BASE_URL }}/user/delete?key={{ key }}">
-        <paper-button raised class="anchor-button">Delete User
-      </paper-button></a>
-      <a href="{{ BASE_URL }}/user/getInviteCode?key={{ key }}">
-        <paper-button raised class="anchor-button">Get Invite Code
-      </paper-button></a>
-      <a href="{{ BASE_URL }}/user/getNewToken?key={{ key }}">
-        <paper-button raised class="anchor-button">Get New Token
-      </paper-button></a>
-      <a href="{{ BASE_URL }}/user/toggleRevoked?key={{ key }}">
-        <paper-button raised class="anchor-button">Revoke/Unrevoke Access
-      </paper-button></a>
-    </paper-item>
-    <br />
-  {% endfor %}
-  </paper-listbox></paper-card>
+  <paper-card heading="Users">
+    <div class="card-content">
+      <p>Click a user below to view more details.</p>
+      <paper-listbox>
+      {% for key, email in user_payloads.iteritems() %}
+        <a href="{{ BASE_URL }}/user/details?key={{ key }}">
+          <paper-item>{{ email }}</paper-item></a>
+      {% endfor %}
+      </paper-listbox></div>
+  </paper-card>
 {% endblock %}

--- a/templates/user_details.html
+++ b/templates/user_details.html
@@ -1,0 +1,46 @@
+{% extends "templates/base.html" %}
+{% block title %}User Details{% endblock %}
+{% block head %}
+  <link rel="import" href="/bower_components/iron-collapse/iron-collapse.html" />
+  <link rel="import" href="/bower_components/paper-button/paper-button.html" />
+  <link rel="import" href="/bower_components/paper-card/paper-card.html" />
+{% endblock %}
+{% block body %}
+  <div id="user-card-holder">
+    <paper-card heading="{{ user.name }}">
+      <div class="card-content">
+        <p>{{ user.name }}, {{ user.email }}</p>
+        <p>Access Status: <b>
+          {% if user.is_key_revoked %}
+            Revoked
+          {% else %}
+            Enabled
+          {% endif %}
+        </b></p>
+        <paper-button onclick="toggleCollapse('collapse-pri')">Show/hide SSH Private Key</paper-button>
+        <iron-collapse id="collapse-pri"><div>{{ user.private_key }}</div></iron-collapse><br>
+        <paper-button onclick="toggleCollapse('collapse-pub')">Show/hide SSH Public Key</paper-button>
+        <iron-collapse id="collapse-pub"><div>{{ user.public_key }}</div></iron-collapse>
+      </div>
+      <div class="card-actions">
+        <a href="{{ BASE_URL }}/user/delete?key={{ key }}">
+          <paper-button raised class="anchor-button">Delete User
+        </paper-button></a>
+        <a href="{{ BASE_URL }}/user/getInviteCode?key={{ key }}">
+          <paper-button raised class="anchor-button">Get Invite Code
+        </paper-button></a>
+        <a href="{{ BASE_URL }}/user/getNewToken?key={{ key }}">
+          <paper-button raised class="anchor-button">Get New Token
+        </paper-button></a>
+        <a href="{{ BASE_URL }}/user/toggleRevoked?key={{ key }}">
+          <paper-button raised class="anchor-button">Revoke/Unrevoke Access
+        </paper-button></a>
+      </div>
+    </paper-card>
+    {% if invite_code %}
+      <paper-card heading="Invite Code Below">
+        <textarea rows="20" cols="80">{{ invite_code }}</textarea><br>
+      </paper-card>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/tests/ui/sidebar.py
+++ b/tests/ui/sidebar.py
@@ -9,7 +9,6 @@ class Sidebar(BaseDriver):
 
   HOME_LINK = (By.ID, 'Home')
   USERS_LINK = (By.ID, 'Users')
-  TOKENS_LINK = (By.ID, 'Tokens')
   PROXY_SERVERS_LINK = (By.ID, 'Proxy Servers')
   SETUP_LINK = (By.ID, 'Setup')
   LOGOUT_LINK = (By.ID, 'Logout')

--- a/tests/ui/sidebar_test.py
+++ b/tests/ui/sidebar_test.py
@@ -23,14 +23,11 @@ class SidebarTest(unittest.TestCase):
     users_link = sidebar.GetLink(sidebar.USERS_LINK)
     self.assertEquals('/user', users_link.get_attribute('data-href'))
 
-    tokens_link = sidebar.GetLink(sidebar.TOKENS_LINK)
-    self.assertEquals('/user/listTokens', tokens_link.get_attribute('data-href'))
-
     proxy_servers_link = sidebar.GetLink(sidebar.PROXY_SERVERS_LINK)
     self.assertEquals('/proxyserver/list', proxy_servers_link.get_attribute('data-href'))
-  
+
     setup_link = sidebar.GetLink(sidebar.SETUP_LINK)
-    self.assertEquals('/setup/oauthclient', setup_link.get_attribute('data-href'))
+    self.assertEquals('/setup', setup_link.get_attribute('data-href'))
 
     logout_link = sidebar.GetLink(sidebar.LOGOUT_LINK)
     self.assertEquals('/logout', logout_link.get_attribute('data-href'))

--- a/tests/ui/user_page.py
+++ b/tests/ui/user_page.py
@@ -7,14 +7,10 @@ class UserPage(BaseDriver):
   """User page action methods and locators."""
 
   ADD_USERS_LINK = (By.ID, 'add_users')
-  LIST_TOKENS_LINK = (By.ID, 'list_tokens')
 
 
   def GetAddUserLink(self):
     return self.driver.find_element(*self.ADD_USERS_LINK)
-
-  def GetListTokensLink(self):
-    return self.driver.find_element(*self.LIST_TOKENS_LINK)
 
   def GetSidebar(self):
     return self.driver.find_element(*Sidebar.SIDEBAR)

--- a/tests/ui/user_page_test.py
+++ b/tests/ui/user_page_test.py
@@ -15,12 +15,10 @@ class UserPageTest(unittest.TestCase):
 
   def testUserPage(self):
     add_users = (u'Add Users').upper()
-    list_tokens = (u'List Tokens').upper()
 
     self.driver.get('http://localhost:9999/user')
     user_page = UserPage(self.driver)
     self.assertEquals(add_users, user_page.GetAddUserLink().text)
-    self.assertEquals(list_tokens, user_page.GetListTokensLink().text)
     self.assertIsNotNone(user_page.GetSidebar())
 
   def tearDown(self):


### PR DESCRIPTION
Point all user actions into a new user details page which shows all the information pertaining to an individual user. This removes the list token handler, which is no longer useful and updates the setup handler to just be under /setup instead of /setup/oauthclient since there is only one setup step now.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server/49)
<!-- Reviewable:end -->
