### PR TITLE
Make the webdriver tests run against real servers.

### DIFF
--- a/tests/ui/base_test.py
+++ b/tests/ui/base_test.py
@@ -6,4 +6,3 @@ class BaseTest(unittest.TestCase):
   def __init__(self, methodName='runTest', args=None):
     super(BaseTest, self).__init__(methodName)
     self.args = args
- 

--- a/tests/ui/base_test.py
+++ b/tests/ui/base_test.py
@@ -1,0 +1,9 @@
+import unittest
+
+class BaseTest(unittest.TestCase):
+  """Base test"""
+
+  def __init__(self, methodName='runTest', args=None):
+    super(BaseTest, self).__init__(methodName)
+    self.args = args
+ 

--- a/tests/ui/landing_page_test.py
+++ b/tests/ui/landing_page_test.py
@@ -1,6 +1,5 @@
 import unittest
 
-from base_driver import BaseDriver
 from base_test import BaseTest
 from login_page import LoginPage
 from landing_page import LandingPage

--- a/tests/ui/landing_page_test.py
+++ b/tests/ui/landing_page_test.py
@@ -1,24 +1,28 @@
 import unittest
 
-from login_page import DevServerLoginPage
+from base_driver import BaseDriver
+from base_test import BaseTest
+from login_page import LoginPage
 from landing_page import LandingPage
 from test_config import CHROME_DRIVER_LOCATION
 
 from selenium import webdriver
 
 
-class LandingPageTest(unittest.TestCase):
+class LandingPageTest(BaseTest):
 
   def setUp(self):
+    """Setup for test methods."""
     self.driver = webdriver.Chrome(CHROME_DRIVER_LOCATION)
-    DevServerLoginPage(self.driver).Login()
+    LoginPage(self.driver).Login(self.args)
 
   def testLandingPage(self):
+    """Test the landing page."""
     title = 'UfO Management Server'
     instruction = ('Click one of the links on the side to login and '
                    'administer the server.')
 
-    self.driver.get('http://localhost:9999')
+    self.driver.get(self.args.server_url)
 
     landing_page = LandingPage(self.driver)
     self.assertEquals(title, landing_page.GetTitle().text)
@@ -26,6 +30,7 @@ class LandingPageTest(unittest.TestCase):
     self.assertIsNotNone(landing_page.GetSidebar())
 
   def tearDown(self):
+    """Teardown for test methods."""
     self.driver.quit()
 
 

--- a/tests/ui/login_page.py
+++ b/tests/ui/login_page.py
@@ -1,25 +1,60 @@
 from base_driver import BaseDriver
 
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
 
-class DevServerLoginPage(BaseDriver):
-  """Login page action methods and locators."""
-
-  EMAIL_INPUT = (By.ID, 'email')
-  ADMIN_CHECKBOX = (By.ID, 'admin')
-  LOGIN_BUTTON = (By.ID, 'submit-login')
 
 
-  def Login(self):
-    self.driver.get('http://localhost:9999/user')
+class LoginPage(BaseDriver):
+  """The Google login page (not the fake dev server login)."""
+
+  EMAIL_INPUT = (By.ID, 'Email')
+  NEXT_BUTTON = (By.ID, 'next')
+  PASSWORD_INPUT = (By.ID, 'Passwd')
+  SIGN_IN_BUTTON = (By.ID, 'signIn')
+  APP_APPROVE_BUTTON = (By.ID, 'approve_button')
+  OAUTH_SCOPES = (By.ID, 'scope_list')
+  OAUTH_APPROVE_BUTTON = (By.ID, 'submit_approve_access')
+
+  REMEMBER_APPROVAL_MESSAGE = 'Remember this approval for the next 30 days'
+
+  def _IsElementPresent(self, locator):
+    """Determines if element is present."""
+    try:
+      self.driver.find_element(*locator)
+    except NoSuchElementException, e:
+      return False
+    return True
+
+  def Login(self, args):
+    """Go through the login and authorization flows."""
+    self.driver.get(args.server_url + '/user')
 
     email_input = self.driver.find_element(*self.EMAIL_INPUT)
-    email_input.clear()
-    email_input.send_keys('henry@henrychang.mygbiz.com')
+    email_input.send_keys(args.email)
 
-    admin_checkbox = self.driver.find_element(*self.ADMIN_CHECKBOX)
-    admin_checkbox.click()
+    next_button = self.driver.find_element(*self.NEXT_BUTTON)
+    next_button.click()
 
-    login_button = self.driver.find_element(*self.LOGIN_BUTTON)
-    login_button.click()
+    password_input = WebDriverWait(self.driver, 10).until(
+        EC.presence_of_element_located(((self.PASSWORD_INPUT))))
+    password_input.send_keys(args.password)
+
+    sign_in_button = self.driver.find_element(*self.SIGN_IN_BUTTON)
+    sign_in_button.click()
+
+    # App approval page.
+    # This needs to be reapproved every 30 days.
+    if self.REMEMBER_APPROVAL_MESSAGE in self.driver.page_source:
+      app_approve_button = self.driver.find_element(*self.APP_APPROVE_BUTTON)
+      app_approve_button.click()
+
+    # OAuth Page
+    if self._IsElementPresent(self.OAUTH_SCOPES):
+      oauth_approve_button = WebDriverWait(self.driver, 10).until(
+        EC.element_to_be_clickable((self.OAUTH_APPROVE_BUTTON)))
+      oauth_approve_button.click()

--- a/tests/ui/login_page.py
+++ b/tests/ui/login_page.py
@@ -56,5 +56,5 @@ class LoginPage(BaseDriver):
     # OAuth Page
     if self._IsElementPresent(self.OAUTH_SCOPES):
       oauth_approve_button = WebDriverWait(self.driver, 10).until(
-        EC.element_to_be_clickable((self.OAUTH_APPROVE_BUTTON)))
+          EC.element_to_be_clickable((self.OAUTH_APPROVE_BUTTON)))
       oauth_approve_button.click()

--- a/tests/ui/login_page.py
+++ b/tests/ui/login_page.py
@@ -48,7 +48,7 @@ class LoginPage(BaseDriver):
     sign_in_button.click()
 
     # App approval page.
-    # This needs to be reapproved every 30 days.
+    # This page will reappear every 30 days.
     if self.REMEMBER_APPROVAL_MESSAGE in self.driver.page_source:
       app_approve_button = self.driver.find_element(*self.APP_APPROVE_BUTTON)
       app_approve_button.click()

--- a/tests/ui/sidebar_test.py
+++ b/tests/ui/sidebar_test.py
@@ -1,6 +1,7 @@
 import unittest
 
-from login_page import DevServerLoginPage
+from base_test import BaseTest
+from login_page import LoginPage
 from sidebar import Sidebar
 from test_config import CHROME_DRIVER_LOCATION
 from user_page import UserPage
@@ -8,13 +9,15 @@ from user_page import UserPage
 from selenium import webdriver
 
 
-class SidebarTest(unittest.TestCase):
+class SidebarTest(BaseTest):
 
   def setUp(self):
+    """Setup for test methods."""
     self.driver = webdriver.Chrome(CHROME_DRIVER_LOCATION)
-    DevServerLoginPage(self.driver).Login()
+    LoginPage(self.driver).Login(self.args)
 
   def testLinks(self):
+    """Make sure all the links are pointed to the correct paths."""
     sidebar = Sidebar(self.driver)
     home_link = sidebar.GetLink(sidebar.HOME_LINK)
     # TODO: Make the path to be importable.
@@ -36,6 +39,7 @@ class SidebarTest(unittest.TestCase):
     self.assertEquals('/logout', logout_link.get_attribute('data-href'))
 
   def tearDown(self):
+    """Teardown for test methods."""
     self.driver.quit()
 
 

--- a/tests/ui/ui_test_suite.py
+++ b/tests/ui/ui_test_suite.py
@@ -1,0 +1,38 @@
+import argparse
+import sys
+import unittest
+
+from landing_page_test import LandingPageTest
+from sidebar_test import SidebarTest
+from user_page_test import UserPageTest
+
+
+def _ParseArgs():
+  """Parse the arguments from the commandline."""
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--server_url', action='store',
+                      dest='server_url', default=None,
+                      help='URL of the server to test.')
+  parser.add_argument('--email', action='store',
+                      dest='email', default=None,
+                      help='Email of the user to login.')
+  parser.add_argument('--password', action='store',
+                      dest='password', default=None,
+                      help='Password of the user to login.')
+  return parser.parse_args()
+
+def MakeSuite(testcase_class):
+  """Add the test cases into suites."""
+  testloader = unittest.TestLoader()
+  testnames = testloader.getTestCaseNames(testcase_class)
+  suite = unittest.TestSuite()
+  for name in testnames:
+    suite.addTest(testcase_class(name, args=_ParseArgs()))
+  return suite
+
+suite = unittest.TestSuite()
+suite.addTest(MakeSuite(LandingPageTest))
+suite.addTest(MakeSuite(UserPageTest))
+suite.addTest(MakeSuite(SidebarTest))
+
+unittest.TextTestRunner().run(suite)

--- a/tests/ui/ui_test_suite.py
+++ b/tests/ui/ui_test_suite.py
@@ -23,10 +23,10 @@ def _ParseArgs():
 def MakeSuite(testcase_class):
   """Add the test cases into suites."""
   testloader = unittest.TestLoader()
-  testnames = testloader.getTestCaseNames(testcase_class)
+  test_cases = testloader.getTestCaseNames(testcase_class)
   suite = unittest.TestSuite()
-  for name in testnames:
-    suite.addTest(testcase_class(name, args=_ParseArgs()))
+  for test_case in test_cases:
+    suite.addTest(testcase_class(test_case, args=_ParseArgs()))
   return suite
 
 suite = unittest.TestSuite()

--- a/tests/ui/ui_test_suite.py
+++ b/tests/ui/ui_test_suite.py
@@ -1,5 +1,4 @@
 import argparse
-import sys
 import unittest
 
 from landing_page_test import LandingPageTest

--- a/tests/ui/user_page_test.py
+++ b/tests/ui/user_page_test.py
@@ -1,29 +1,33 @@
 import unittest
 
-from login_page import DevServerLoginPage
+from base_test import BaseTest
+from login_page import LoginPage
 from test_config import CHROME_DRIVER_LOCATION
 from user_page import UserPage
 
 from selenium import webdriver
 
 
-class UserPageTest(unittest.TestCase):
+class UserPageTest(BaseTest):
 
   def setUp(self):
+    """Setup for test methods."""
     self.driver = webdriver.Chrome(CHROME_DRIVER_LOCATION)
-    DevServerLoginPage(self.driver).Login()
+    LoginPage(self.driver).Login(self.args)
 
   def testUserPage(self):
+    """Test the user page."""
     add_users = (u'Add Users').upper()
     list_tokens = (u'List Tokens').upper()
 
-    self.driver.get('http://localhost:9999/user')
+    self.driver.get(self.args.server_url + '/user')
     user_page = UserPage(self.driver)
     self.assertEquals(add_users, user_page.GetAddUserLink().text)
     self.assertEquals(list_tokens, user_page.GetListTokensLink().text)
     self.assertIsNotNone(user_page.GetSidebar())
 
   def tearDown(self):
+    """Teardown for test methods."""
     self.driver.quit()
 
 


### PR DESCRIPTION
This PR gives us a more effective way to make the webdriver tests useful.

- by running against real servers

- by allowing commandline arguments to be passed to the tests, so that we can define what server to test, which test account to use, and what's the password

python ui_test_suite.py 
    --server_url=<foo url> 
    --email=<foo email>
    --password=<foo password>

- because these tests run against the real servers, I expect we can use these tests on staging to validate a server before release

- developers will be expected to run and update these tests against their test servers for each PR

- real account needs to be setup and used for these tests

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server/50)
<!-- Reviewable:end -->
