### PR TITLE
Implement Push Notifications for Watching Changes to the Users Resource

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -46,6 +46,14 @@ handlers:
   login: required
   secure: always
 
+- url: /sync.*
+  script: sync.APP
+  login: required
+  secure: always
+
+- url: /receive
+  script: sync.APP
+
 - url: /user.*
   script: user.APP
   login: required

--- a/css/custom.css
+++ b/css/custom.css
@@ -31,3 +31,7 @@ paper-card {
 #user-card-holder {
   max-width: 600px;
 }
+
+#channels-card-holder {
+  max-width: 600px;
+}

--- a/datastore.py
+++ b/datastore.py
@@ -243,6 +243,51 @@ class ProxyServer(BaseModel):
     entity.put()
 
 
+class Notification(BaseModel):
+
+  """Store data related to notifications."""
+
+  state = ndb.StringProperty()
+  number = ndb.StringProperty()
+  uuid = ndb.StringProperty()
+  email = ndb.StringProperty()
+
+  @staticmethod
+  def Insert(state, number, uuid, email):
+    """Insert a new Notification entity in the datastore with the given values.
+
+    Args:
+      state: The X-Goog-Resource-State field of the request.
+      number: The X-Goog-Message-Number field of the request.
+      uuid: The id field of the request body.
+      email: The primaryEmail field of the request body.
+    """
+    entity = Notification(state=state, number=number, uuid=uuid, email=email)
+    entity.put()
+
+
+class NotificationChannels(BaseModel):
+
+  """Store data related to notifications."""
+
+  event = ndb.StringProperty()
+  channel_id = ndb.StringProperty()
+  resource_id = ndb.StringProperty()
+
+  @staticmethod
+  def Insert(event, channel_id, resource_id):
+    """Insert a new Notification Channel entity in the datastore as specified.
+
+    Args:
+      event: The event subscribed to in the channel.
+      channel_id: The unique id this app sets for the channel.
+      resource_id: The universally unique id the directory API sets for us.
+    """
+    entity = NotificationChannels(event=event, channel_id=channel_id,
+                                  resource_id=resource_id)
+    entity.put()
+
+
 class OAuth(BaseModel):
 
   """Store the client secret so that it's not checked into source code.

--- a/datastore.py
+++ b/datastore.py
@@ -266,9 +266,9 @@ class Notification(BaseModel):
     entity.put()
 
 
-class NotificationChannels(BaseModel):
+class NotificationChannel(BaseModel):
 
-  """Store data related to notifications."""
+  """Store data related to notification channels."""
 
   event = ndb.StringProperty()
   channel_id = ndb.StringProperty()
@@ -283,8 +283,8 @@ class NotificationChannels(BaseModel):
       channel_id: The unique id this app sets for the channel.
       resource_id: The universally unique id the directory API sets for us.
     """
-    entity = NotificationChannels(event=event, channel_id=channel_id,
-                                  resource_id=resource_id)
+    entity = NotificationChannel(event=event, channel_id=channel_id,
+                                 resource_id=resource_id)
     entity.put()
 
 

--- a/datastore_test.py
+++ b/datastore_test.py
@@ -377,7 +377,6 @@ class NotificationDatastoreTest(DatastoreTest):
     """Test that a new notification is properly inserted and found after."""
     self.assertEqual(datastore.Notification.GetCount(), 0)
 
-
     datastore.Notification.Insert(FAKE_STATE, FAKE_NUMBER, FAKE_UUID,
                                   FAKE_EMAIL)
 
@@ -396,14 +395,13 @@ class NotificationChannelDSTest(DatastoreTest):
 
   def testInsert(self):
     """Test that a new notification channel is properly inserted and found."""
-    self.assertEqual(datastore.NotificationChannels.GetCount(), 0)
+    self.assertEqual(datastore.NotificationChannel.GetCount(), 0)
 
-
-    datastore.NotificationChannels.Insert(FAKE_EVENT, FAKE_CHANNEL_ID,
+    datastore.NotificationChannel.Insert(FAKE_EVENT, FAKE_CHANNEL_ID,
                                           FAKE_RESOURCE_ID)
 
-    self.assertEqual(datastore.NotificationChannels.GetCount(), 1)
-    channels_after_insert = datastore.NotificationChannels.GetAll()
+    self.assertEqual(datastore.NotificationChannel.GetCount(), 1)
+    channels_after_insert = datastore.NotificationChannel.GetAll()
     for channel in channels_after_insert:
       self.assertEqual(channel.event, FAKE_EVENT)
       self.assertEqual(channel.channel_id, FAKE_CHANNEL_ID)

--- a/datastore_test.py
+++ b/datastore_test.py
@@ -398,7 +398,7 @@ class NotificationChannelDSTest(DatastoreTest):
     self.assertEqual(datastore.NotificationChannel.GetCount(), 0)
 
     datastore.NotificationChannel.Insert(FAKE_EVENT, FAKE_CHANNEL_ID,
-                                          FAKE_RESOURCE_ID)
+                                         FAKE_RESOURCE_ID)
 
     self.assertEqual(datastore.NotificationChannel.GetCount(), 1)
     channels_after_insert = datastore.NotificationChannel.GetAll()

--- a/datastore_test.py
+++ b/datastore_test.py
@@ -68,6 +68,7 @@ class DatastoreTest(unittest.TestCase):
   """Test basic datastore class functionality."""
 
   def setUp(self):
+    """Setup the testbed for each test class."""
     # First, create an instance of the Testbed class.
     self.testbed = testbed.Testbed()
     # Then activate the testbed, which prepares the service stubs for use.
@@ -103,9 +104,11 @@ class DatastoreTest(unittest.TestCase):
                                   is_key_revoked=False)
 
   def tearDown(self):
+    """Deactive the testbed."""
     self.testbed.deactivate()
 
   def testGetCount(self):
+    """Test that the count of entities of a given type is returned."""
     self.assertEqual(datastore.User.GetCount(), 0)
 
     FAKE_USER.put()
@@ -115,6 +118,7 @@ class DatastoreTest(unittest.TestCase):
     self.assertEqual(datastore.User.GetCount(), 2)
 
   def testGetAll(self):
+    """Test that all entities of a given type are found and returned."""
     self.assertEqual(datastore.User.GetAll(), [])
     self.assertEqual(len(datastore.User.GetAll()), datastore.User.GetCount())
 
@@ -129,6 +133,7 @@ class DatastoreTest(unittest.TestCase):
     self.assertEqual(len(datastore.User.GetAll()), datastore.User.GetCount())
 
   def testGet(self):
+    """Test that an entity is found by id and returned from the datastore."""
     self.assertEqual(datastore.User.Get(FAKE_KEY.id()), None)
     self.assertEqual(datastore.User.Get(BAD_KEY.id()), None)
 
@@ -141,6 +146,7 @@ class DatastoreTest(unittest.TestCase):
     self.assertEqual(datastore.User.Get(BAD_KEY.id()), USER_BAD_KEY)
 
   def testGetByKey(self):
+    """Test that an entity is found by key and returned from the datastore."""
     self.assertEqual(datastore.User.GetByKey(FAKE_KEY_URLSAFE), None)
     self.assertEqual(datastore.User.GetByKey(BAD_KEY_URLSAFE), None)
 
@@ -153,6 +159,7 @@ class DatastoreTest(unittest.TestCase):
     self.assertEqual(datastore.User.GetByKey(BAD_KEY_URLSAFE), USER_BAD_KEY)
 
   def testDelete(self):
+    """Test that an entity is found by id and removed from the datastore."""
     FAKE_USER.put()
     USER_BAD_KEY.put()
     self.assertTrue(FAKE_USER in datastore.User.GetAll())
@@ -169,6 +176,7 @@ class DatastoreTest(unittest.TestCase):
     self.assertTrue(USER_BAD_KEY not in datastore.User.GetAll())
 
   def testDeleteByKey(self):
+    """Test that an entity is found by key and removed from the datastore."""
     FAKE_USER.put()
     USER_BAD_KEY.put()
     self.assertTrue(FAKE_USER in datastore.User.GetAll())
@@ -193,6 +201,7 @@ class UserDatastoreTest(DatastoreTest):
   @patch('hashlib.sha256.hexdigest')
   @patch.object(datastore.hashlib, 'sha256')
   def testCreateUser(self, mock_sha, mock_hex, mock_key):
+    """Test that a new user entity is created with the associated fields."""
     fake_hex_email = '0x12345678'
     mock_hex.return_value = fake_hex_email
     mock_sha.return_value.hexdigest = mock_hex
@@ -215,6 +224,7 @@ class UserDatastoreTest(DatastoreTest):
   @patch('datastore.RSA._RSAobj.exportKey')
   @patch.object(datastore.RSA, 'generate')
   def testGenerateKeyPair(self, mock_rsa, mock_exp, mock_pub, mock_encode):
+    """Test that a new key pair is created successfully."""
     mock_encode.return_value = FAKE_PRIVATE_KEY
     mock_exp.return_value = FAKE_PRIVATE_KEY
     mock_pub.return_value.exportKey = mock_exp
@@ -233,6 +243,7 @@ class UserDatastoreTest(DatastoreTest):
 
   @patch('datastore.User._GenerateKeyPair')
   def testUpdateKeyPair(self, mock_generate):
+    """Test the key pair is updated for a given user."""
     USER_BAD_KEY.put()
     user_before_test = datastore.User.GetByKey(BAD_KEY_URLSAFE)
     self.assertEqual(user_before_test.public_key, BAD_PUB_PRI_KEY)
@@ -248,6 +259,7 @@ class UserDatastoreTest(DatastoreTest):
     self.assertEqual(user_after_test.private_key, FAKE_PRIVATE_KEY)
 
   def testToggleKeyRevoked(self):
+    """Test the is_key_revoked property is flipped on each call."""
     FAKE_USER.put()
     user_before_test = datastore.User.GetByKey(FAKE_KEY_URLSAFE)
     self.assertEqual(user_before_test.is_key_revoked, False)
@@ -264,6 +276,7 @@ class UserDatastoreTest(DatastoreTest):
 
   @patch('datastore.User._CreateUser')
   def testInsertUser(self, mock_create):
+    """Test that a new user is inserted and found after."""
     mock_create.return_value = FAKE_USER
 
     user_before_test = datastore.User.GetByKey(FAKE_KEY_URLSAFE)
@@ -315,6 +328,7 @@ class ProxyServerDatastoreTest(DatastoreTest):
   """Test proxy server datastore class functionality."""
 
   def testInsert(self):
+    """Test that a new proxy server is properly inserted and found after."""
     self.assertEqual(datastore.ProxyServer.GetCount(), 0)
 
     datastore.ProxyServer.Insert(FAKE_PROXY_SERVER_NAME, FAKE_IP,
@@ -329,6 +343,7 @@ class ProxyServerDatastoreTest(DatastoreTest):
       self.assertEqual(proxy.fingerprint, FAKE_FINGERPRINT)
 
   def testUpdate(self):
+    """Test that an existing proxy server is properly updated."""
     bad_proxy = datastore.ProxyServer(name=BAD_PROXY_SERVER_NAME,
                                       ip_address=BAD_IP,
                                       ssh_private_key=BAD_SSH_PRI_KEY,
@@ -359,6 +374,7 @@ class NotificationDatastoreTest(DatastoreTest):
   """Test notification datastore class functionality."""
 
   def testInsert(self):
+    """Test that a new notification is properly inserted and found after."""
     self.assertEqual(datastore.Notification.GetCount(), 0)
 
 
@@ -379,6 +395,7 @@ class NotificationChannelDSTest(DatastoreTest):
   """Test notification channels datastore class functionality."""
 
   def testInsert(self):
+    """Test that a new notification channel is properly inserted and found."""
     self.assertEqual(datastore.NotificationChannels.GetCount(), 0)
 
 
@@ -398,6 +415,7 @@ class OAuthDatastoreTest(DatastoreTest):
   """Test oauth datastore class functionality."""
 
   def testGetOrInsertDefault(self):
+    """Test that an entity is always returned and insert if necessary."""
     self.assertEqual(datastore.OAuth.GetCount(), 0)
 
     first_entity = datastore.OAuth.GetOrInsertDefault()
@@ -417,6 +435,7 @@ class OAuthDatastoreTest(DatastoreTest):
     self.assertEqual(second_entity.client_secret, FAKE_CLIENT_SECRET)
 
   def testInsertDefault(self):
+    """Test that a default entity is inserted and found afterwards."""
     self.assertEqual(datastore.OAuth.GetCount(), 0)
 
     datastore.OAuth.InsertDefault()
@@ -429,6 +448,7 @@ class OAuthDatastoreTest(DatastoreTest):
       self.assertEqual(client.client_secret, datastore.OAuth.DEFAULT_SECRET)
 
   def testInsert(self):
+    """Test that an entity is inserted and found afterwards."""
     self.assertEqual(datastore.OAuth.GetCount(), 0)
 
     datastore.OAuth.Insert(FAKE_CLIENT_ID, FAKE_CLIENT_SECRET)
@@ -441,6 +461,7 @@ class OAuthDatastoreTest(DatastoreTest):
       self.assertEqual(client.client_secret, FAKE_CLIENT_SECRET)
 
   def testUpdate(self):
+    """Test that an existing entity is updated with new values."""
     datastore.OAuth.Insert(BAD_CLIENT_ID, BAD_CLIENT_SECRET)
 
     self.assertEqual(datastore.OAuth.GetCount(), 1)
@@ -457,6 +478,7 @@ class OAuthDatastoreTest(DatastoreTest):
 
   @patch('datastore.memcache.flush_all')
   def testFlush(self, mock_flush_all):
+    """Test that oauth is flushed from the memcache."""
     # pylint: disable=no-self-use
     datastore.OAuth.Flush()
 
@@ -467,6 +489,7 @@ class DomainVerificationDatastoreTest(DatastoreTest):
   """Test domain verification datastore class functionality."""
 
   def testGetOrInsertDefault(self):
+    """Test that an entity is always returned and insert if necessary."""
     self.assertEqual(DomainVerification.GetCount(), 0)
 
     first_entity = DomainVerification.GetOrInsertDefault()
@@ -487,6 +510,7 @@ class DomainVerificationDatastoreTest(DatastoreTest):
     self.assertEqual(second_entity.content, FAKE_CONTENT)
 
   def testInsertDefault(self):
+    """Test that a default entity is inserted and found afterwards."""
     self.assertEqual(DomainVerification.GetCount(), 0)
 
     DomainVerification.InsertDefault()
@@ -499,6 +523,7 @@ class DomainVerificationDatastoreTest(DatastoreTest):
                      DomainVerification.DEFAULT_CONTENT)
 
   def testInsert(self):
+    """Test that an entity is inserted and found afterwards."""
     self.assertEqual(DomainVerification.GetCount(), 0)
 
     DomainVerification.Insert(FAKE_CONTENT)
@@ -510,6 +535,7 @@ class DomainVerificationDatastoreTest(DatastoreTest):
     self.assertEqual(dv_after_insert.content, FAKE_CONTENT)
 
   def testUpdate(self):
+    """Test that an existing entity is updated with new values."""
     DomainVerification.Insert(BAD_CONTENT)
 
     self.assertEqual(DomainVerification.GetCount(), 1)

--- a/datastore_test.py
+++ b/datastore_test.py
@@ -52,6 +52,16 @@ BAD_CLIENT_SECRET = 'secret 123'  # noqa
 FAKE_CONTENT = 'foo'
 BAD_CONTENT = 'bar'
 
+# Notification test globals
+FAKE_STATE = 'delete'
+FAKE_NUMBER = '1000000'
+FAKE_UUID = '123087632460958036'
+
+# Notification Channels test globals
+FAKE_EVENT = 'delete'
+FAKE_CHANNEL_ID = 'foo customer_delete_time-in-millis'
+FAKE_RESOURCE_ID = 'i am a fake resource id'
+
 
 class DatastoreTest(unittest.TestCase):
 
@@ -342,6 +352,45 @@ class ProxyServerDatastoreTest(DatastoreTest):
     self.assertEqual(proxy_after_update.ip_address, FAKE_IP)
     self.assertEqual(proxy_after_update.ssh_private_key, FAKE_SSH_PRI_KEY)
     self.assertEqual(proxy_after_update.fingerprint, FAKE_FINGERPRINT)
+
+
+class NotificationDatastoreTest(DatastoreTest):
+
+  """Test notification datastore class functionality."""
+
+  def testInsert(self):
+    self.assertEqual(datastore.Notification.GetCount(), 0)
+
+
+    datastore.Notification.Insert(FAKE_STATE, FAKE_NUMBER, FAKE_UUID,
+                                  FAKE_EMAIL)
+
+    self.assertEqual(datastore.Notification.GetCount(), 1)
+    notifications_after_insert = datastore.Notification.GetAll()
+    for notification in notifications_after_insert:
+      self.assertEqual(notification.state, FAKE_STATE)
+      self.assertEqual(notification.number, FAKE_NUMBER)
+      self.assertEqual(notification.uuid, FAKE_UUID)
+      self.assertEqual(notification.email, FAKE_EMAIL)
+
+
+class NotificationChannelDSTest(DatastoreTest):
+
+  """Test notification channels datastore class functionality."""
+
+  def testInsert(self):
+    self.assertEqual(datastore.NotificationChannels.GetCount(), 0)
+
+
+    datastore.NotificationChannels.Insert(FAKE_EVENT, FAKE_CHANNEL_ID,
+                                          FAKE_RESOURCE_ID)
+
+    self.assertEqual(datastore.NotificationChannels.GetCount(), 1)
+    channels_after_insert = datastore.NotificationChannels.GetAll()
+    for channel in channels_after_insert:
+      self.assertEqual(channel.event, FAKE_EVENT)
+      self.assertEqual(channel.channel_id, FAKE_CHANNEL_ID)
+      self.assertEqual(channel.resource_id, FAKE_RESOURCE_ID)
 
 
 class OAuthDatastoreTest(DatastoreTest):

--- a/google_directory_service.py
+++ b/google_directory_service.py
@@ -1,6 +1,6 @@
 """Module to interact with Google Directory API."""
 
-from datastore import NotificationChannels
+from datastore import NotificationChannel
 from googleapiclient.discovery import build
 from time import time
 
@@ -135,7 +135,7 @@ class GoogleDirectoryService(object):
       return
 
     # Don't subscribe if we have already subscribed.
-    channels = NotificationChannels.GetAll()
+    channels = NotificationChannel.GetAll()
     for channel in channels:
       if channel.event == event:
         return
@@ -155,14 +155,14 @@ class GoogleDirectoryService(object):
     result = request.execute(num_retries=NUM_RETRIES)
 
     if 'resourceId' in result:
-      NotificationChannels.Insert(event=event, channel_id=id_field,
+      NotificationChannel.Insert(event=event, channel_id=id_field,
                                   resource_id=result['resourceId'])
 
   def StopNotifications(self, notification_channel):
     """Unsubscribe from notifications for a given notification channel.
 
     Args:
-      notification_channel: A NotificationChannels datastore entity to unsub.
+      notification_channel: A NotificationChannel datastore entity to unsub.
     """
     body = {}
     body['id'] = notification_channel.channel_id
@@ -170,5 +170,5 @@ class GoogleDirectoryService(object):
     request = self.service.channels().stop(body=body)
     request.execute(num_retries=NUM_RETRIES)
 
-    NotificationChannels.Delete(notification_channel.key.id)
+    NotificationChannel.Delete(notification_channel.key.id)
 

--- a/google_directory_service.py
+++ b/google_directory_service.py
@@ -156,7 +156,7 @@ class GoogleDirectoryService(object):
 
     if 'resourceId' in result:
       NotificationChannel.Insert(event=event, channel_id=id_field,
-                                  resource_id=result['resourceId'])
+                                 resource_id=result['resourceId'])
 
   def StopNotifications(self, notification_channel):
     """Unsubscribe from notifications for a given notification channel.

--- a/google_directory_service.py
+++ b/google_directory_service.py
@@ -168,7 +168,7 @@ class GoogleDirectoryService(object):
     body['id'] = notification_channel.channel_id
     body['resourceId'] = notification_channel.resource_id
     request = self.service.channels().stop(body=body)
-    result = request.execute(num_retries=NUM_RETRIES)
+    request.execute(num_retries=NUM_RETRIES)
 
     NotificationChannels.Delete(notification_channel.key.id)
 

--- a/static/sidebar.js
+++ b/static/sidebar.js
@@ -6,6 +6,7 @@ Polymer({
     {"href": "/user", "text": "Users"},
     {"href": "/proxyserver/list", "text": "Proxy Servers"},
     {"href": "/setup", "text": "Setup"},
+    {"href": "/sync", "text": "Sync Notifications"},
     {"href": "/logout", "text": "Logout"}
     ];
   },

--- a/sync.py
+++ b/sync.py
@@ -63,7 +63,7 @@ class DefaultPathHandler(webapp2.RequestHandler):
   # pylint: disable=too-few-public-methods
 
   @admin.OAUTH_DECORATOR.oauth_required
-  @admin.RequireAppAndDomainAdmin
+  @admin.RequireAppOrDomainAdmin
   def get(self):
     """Redirect to the list of previous notifications."""
     self.redirect(NOTIFICATIONS_PATH)
@@ -76,7 +76,7 @@ class ListChannelsHandler(webapp2.RequestHandler):
   # pylint: disable=too-few-public-methods
 
   @admin.OAUTH_DECORATOR.oauth_required
-  @admin.RequireAppAndDomainAdmin
+  @admin.RequireAppOrDomainAdmin
   def get(self):
     """List all the channels and associated properties in the datastore."""
     self.response.write(_RenderChannelsListTemplate())
@@ -89,7 +89,7 @@ class ListNotificationsHandler(webapp2.RequestHandler):
   # pylint: disable=too-few-public-methods
 
   @admin.OAUTH_DECORATOR.oauth_required
-  @admin.RequireAppAndDomainAdmin
+  @admin.RequireAppOrDomainAdmin
   def get(self):
     """List all previous notifications received."""
     self.response.write(_RenderNotificationsTemplate())
@@ -102,7 +102,7 @@ class WatchUserDeleteEventHandler(webapp2.RequestHandler):
   # pylint: disable=too-few-public-methods
 
   @admin.OAUTH_DECORATOR.oauth_required
-  @admin.RequireAppAndDomainAdmin
+  @admin.RequireAppOrDomainAdmin
   def get(self):
     """Perform a pub/sub for user delete events."""
     try:
@@ -120,7 +120,7 @@ class UnsubscribeHandler(webapp2.RequestHandler):
   # pylint: disable=too-few-public-methods
 
   @admin.OAUTH_DECORATOR.oauth_required
-  @admin.RequireAppAndDomainAdmin
+  @admin.RequireAppOrDomainAdmin
   def get(self):
     """Find the channel specified and unsubscribe from it."""
     datastore_id = int(self.request.get('id'))

--- a/sync.py
+++ b/sync.py
@@ -125,9 +125,12 @@ class UnsubscribeHandler(webapp2.RequestHandler):
     """Find the channel specified and unsubscribe from it."""
     datastore_id = int(self.request.get('id'))
     entity = NotificationChannels.Get(datastore_id)
-    directory_service = GoogleDirectoryService(admin.OAUTH_DECORATOR)
-    directory_service.StopNotifications(entity)
-    self.redirect(CHANNELS_PATH)
+    try:
+      directory_service = GoogleDirectoryService(admin.OAUTH_DECORATOR)
+      directory_service.StopNotifications(entity)
+      self.redirect(CHANNELS_PATH)
+    except errors.HttpError as error:
+      self.response.write('An error occurred: ' + str(error))
 
 
 APP = webapp2.WSGIApplication([

--- a/sync.py
+++ b/sync.py
@@ -1,0 +1,145 @@
+"""The user sync module for handling user changes in the directory service."""
+
+import admin
+from appengine_config import JINJA_ENVIRONMENT
+from datastore import Notification
+from datastore import NotificationChannels
+from error_handlers import Handle500
+from googleapiclient import errors
+from google_directory_service import GoogleDirectoryService
+import json
+import webapp2
+
+
+RECEIVE_NOTIFICATIONS_PATH = '/receive'
+SYNC_RELATIVE_PATH = '/sync'
+CHANNELS_PATH = SYNC_RELATIVE_PATH + '/channels'
+NOTIFICATIONS_PATH = SYNC_RELATIVE_PATH + '/notifications'
+WATCH_FOR_DELETION_PATH = SYNC_RELATIVE_PATH + '/delete'
+UNSUBSCRIBE_PATH = SYNC_RELATIVE_PATH + '/unsubscribe'
+
+def _RenderNotificationsTemplate():
+  """Render a list of notifications."""
+  notifications = Notification.GetAll()
+  template_values = {
+      'notifications': notifications
+  }
+  template = JINJA_ENVIRONMENT.get_template('templates/notifications.html')
+  return template.render(template_values)
+
+def _RenderChannelsListTemplate():
+  """Render a list of notification channels."""
+  channels = NotificationChannels.GetAll()
+  template_values = {
+      'channels': channels
+  }
+  html_file_name = 'templates/notification_channels.html'
+  template = JINJA_ENVIRONMENT.get_template(html_file_name)
+  return template.render(template_values)
+
+
+class PushNotificationHandler(webapp2.RequestHandler):
+
+  """Receive an update about users in the datastore."""
+
+  # pylint: disable=too-few-public-methods
+
+  def post(self):
+    """Receive push notifications and issue some sort of response."""
+    state = self.request.headers.get('X-Goog-Resource-State')
+    number = self.request.headers.get('X-Goog-Message-Number')
+    json_body = self.request.body
+    body_object = json.loads(json_body)
+    uuid = body_object['id']
+    email = body_object['primaryEmail']
+    Notification.Insert(state=state, number=number, uuid=uuid, email=email)
+    self.response.write('Got a notification!')
+
+
+class DefaultPathHandler(webapp2.RequestHandler):
+
+  """Base page for all pages under /sync."""
+
+  # pylint: disable=too-few-public-methods
+
+  @admin.OAUTH_DECORATOR.oauth_required
+  @admin.RequireAppAndDomainAdmin
+  def get(self):
+    """Redirect to the list of previous notifications."""
+    self.redirect(NOTIFICATIONS_PATH)
+
+
+class ListChannelsHandler(webapp2.RequestHandler):
+
+  """List all the channels currently receiving notifications."""
+
+  # pylint: disable=too-few-public-methods
+
+  @admin.OAUTH_DECORATOR.oauth_required
+  @admin.RequireAppAndDomainAdmin
+  def get(self):
+    """List all the channels and associated properties in the datastore."""
+    self.response.write(_RenderChannelsListTemplate())
+
+
+class ListNotificationsHandler(webapp2.RequestHandler):
+
+  """List all the notifications previously received."""
+
+  # pylint: disable=too-few-public-methods
+
+  @admin.OAUTH_DECORATOR.oauth_required
+  @admin.RequireAppAndDomainAdmin
+  def get(self):
+    """List all previous notifications received."""
+    self.response.write(_RenderNotificationsTemplate())
+
+
+class WatchUserDeleteEventHandler(webapp2.RequestHandler):
+
+  """Watch users in the directory API for deletion events."""
+
+  # pylint: disable=too-few-public-methods
+
+  @admin.OAUTH_DECORATOR.oauth_required
+  @admin.RequireAppAndDomainAdmin
+  def get(self):
+    """Perform a pub/sub for user delete events."""
+    try:
+	    directory_service = GoogleDirectoryService(admin.OAUTH_DECORATOR)
+	    directory_service.WatchUsers('delete')
+	    self.redirect(CHANNELS_PATH)
+    except errors.HttpError as error:
+      self.response.write('An error occurred: ' + str(error))
+
+
+class UnsubscribeHandler(webapp2.RequestHandler):
+
+  """Unsubsribe from notifications for a specific resouce."""
+
+  # pylint: disable=too-few-public-methods
+
+  @admin.OAUTH_DECORATOR.oauth_required
+  @admin.RequireAppAndDomainAdmin
+  def get(self):
+    """Find the channel specified and unsubscribe from it."""
+    datastore_id = int(self.request.get('id'))
+    entity = NotificationChannels.Get(datastore_id)
+    directory_service = GoogleDirectoryService(admin.OAUTH_DECORATOR)
+    directory_service.StopNotifications(entity)
+    self.redirect(CHANNELS_PATH)
+
+
+APP = webapp2.WSGIApplication([
+    (RECEIVE_NOTIFICATIONS_PATH, PushNotificationHandler),
+    (SYNC_RELATIVE_PATH, DefaultPathHandler),
+    (CHANNELS_PATH, ListChannelsHandler),
+    (NOTIFICATIONS_PATH, ListNotificationsHandler),
+    (WATCH_FOR_DELETION_PATH, WatchUserDeleteEventHandler),
+    (UNSUBSCRIBE_PATH, UnsubscribeHandler),
+    (admin.OAUTH_DECORATOR.callback_path,
+     admin.OAUTH_DECORATOR.callback_handler()),
+], debug=True)
+
+# This is the only way to catch exceptions from the oauth decorators.
+APP.error_handlers[500] = Handle500

--- a/sync.py
+++ b/sync.py
@@ -106,9 +106,9 @@ class WatchUserDeleteEventHandler(webapp2.RequestHandler):
   def get(self):
     """Perform a pub/sub for user delete events."""
     try:
-	    directory_service = GoogleDirectoryService(admin.OAUTH_DECORATOR)
-	    directory_service.WatchUsers('delete')
-	    self.redirect(CHANNELS_PATH)
+      directory_service = GoogleDirectoryService(admin.OAUTH_DECORATOR)
+      directory_service.WatchUsers('delete')
+      self.redirect(CHANNELS_PATH)
     except errors.HttpError as error:
       self.response.write('An error occurred: ' + str(error))
 

--- a/sync.py
+++ b/sync.py
@@ -3,7 +3,7 @@
 import admin
 from appengine_config import JINJA_ENVIRONMENT
 from datastore import Notification
-from datastore import NotificationChannels
+from datastore import NotificationChannel
 from error_handlers import Handle500
 from googleapiclient import errors
 from google_directory_service import GoogleDirectoryService
@@ -29,7 +29,7 @@ def _RenderNotificationsTemplate():
 
 def _RenderChannelsListTemplate():
   """Render a list of notification channels."""
-  channels = NotificationChannels.GetAll()
+  channels = NotificationChannel.GetAll()
   template_values = {
       'channels': channels
   }
@@ -124,7 +124,7 @@ class UnsubscribeHandler(webapp2.RequestHandler):
   def get(self):
     """Find the channel specified and unsubscribe from it."""
     datastore_id = int(self.request.get('id'))
-    entity = NotificationChannels.Get(datastore_id)
+    entity = NotificationChannel.Get(datastore_id)
     try:
       directory_service = GoogleDirectoryService(admin.OAUTH_DECORATOR)
       directory_service.StopNotifications(entity)

--- a/sync_test.py
+++ b/sync_test.py
@@ -1,0 +1,206 @@
+"""Test sync module functionality."""
+from mock import MagicMock
+from mock import patch
+import sys
+
+from datastore import Notification
+from datastore import NotificationChannels
+from googleapiclient import errors
+from google.appengine.ext import ndb
+import json
+
+import unittest
+import webtest
+
+# Need to mock the decorator at function definition time, i.e. when the module
+# is loaded. http://stackoverflow.com/a/7667621/2830207
+def NoOpDecorator(func):
+  """Mock decorator that passes through any function for testing."""
+  return func
+
+MOCK_ADMIN = MagicMock()
+MOCK_ADMIN.OAUTH_DECORATOR.oauth_required = NoOpDecorator
+MOCK_ADMIN.RequireAppAndDomainAdmin = NoOpDecorator
+sys.modules['admin'] = MOCK_ADMIN
+
+import sync
+
+
+FAKE_STATE = 'delete'
+FAKE_NUMBER = '1000000'
+FAKE_UUID = '123087632460958036'
+FAKE_EMAIL = 'fake_email@example.com'
+FAKE_EVENT = 'delete'
+FAKE_CHANNEL_ID = 'foo customer_delete_time-in-millis'
+FAKE_RESOURCE_ID = 'i am a fake resource id'
+
+
+class UserTest(unittest.TestCase):
+
+  """Test sync class functionality."""
+
+  def setUp(self):
+    """Setup test app on which to call handlers."""
+    self.testapp = webtest.TestApp(sync.APP)
+
+  def testConstants(self):
+    """Test that the constants are as we expect."""
+    self.assertEqual(sync.RECEIVE_NOTIFICATIONS_PATH, '/receive')
+    self.assertEqual(sync.SYNC_RELATIVE_PATH, '/sync')
+    self.assertEqual(sync.CHANNELS_PATH, sync.SYNC_RELATIVE_PATH + '/channels')
+    self.assertEqual(sync.NOTIFICATIONS_PATH,
+    	sync.SYNC_RELATIVE_PATH + '/notifications')
+    self.assertEqual(sync.WATCH_FOR_DELETION_PATH,
+    	sync.SYNC_RELATIVE_PATH + '/delete')
+    self.assertEqual(sync.UNSUBSCRIBE_PATH,
+    	sync.SYNC_RELATIVE_PATH + '/unsubscribe')
+
+  @patch('sync.Notification.Insert')
+  def testPushNotificationHandler(self, mock_insert):
+    """Test that push notifications trigger an insert in the datastore."""
+    params = {}
+    params['id'] = FAKE_UUID
+    params['primaryEmail'] = FAKE_EMAIL
+    json_body = json.dumps(params)
+    headers = {}
+    headers['X-Goog-Resource-State'] = FAKE_STATE
+    headers['X-Goog-Message-Number'] = FAKE_NUMBER
+
+    response = self.testapp.post(sync.RECEIVE_NOTIFICATIONS_PATH, json_body,
+    	                           headers)
+
+    mock_insert.assert_called_once_with(state=FAKE_STATE, number=FAKE_NUMBER,
+    	                                  uuid=FAKE_UUID, email=FAKE_EMAIL)
+    self.assertEqual('Got a notification!' in response, True)
+
+  def testDefaultPathHandler(self):
+    """Test that the default path redirects to the notifications path."""
+    response = self.testapp.get(sync.SYNC_RELATIVE_PATH)
+    self.assertEqual(response.status_int, 302)
+    self.assertEqual(sync.NOTIFICATIONS_PATH in response.location, True)
+
+  @patch('sync._RenderChannelsListTemplate')
+  def testListChannelsHandler(self, mock_channels_template):
+    """Test that the channel handler calls to render the channels."""
+    self.testapp.get(sync.CHANNELS_PATH)
+    mock_channels_template.assert_called_once_with()
+
+  @patch('sync._RenderNotificationsTemplate')
+  def testListNotificationsHandler(self, mock_notifications_template):
+    """Test that the notification handler calls to render the notifications."""
+    self.testapp.get(sync.NOTIFICATIONS_PATH)
+    mock_notifications_template.assert_called_once_with()
+
+  @patch('sync.GoogleDirectoryService.WatchUsers')
+  @patch('sync.GoogleDirectoryService.__init__')
+  def testWatchUserDeleteHandler(self, mock_directory_service,
+  	                             mock_watch_users):
+    """Test the watch user delete handler calls watch users with delete."""
+    # pylint: disable=too-many-arguments
+    mock_directory_service.return_value = None
+
+    response = self.testapp.get(sync.WATCH_FOR_DELETION_PATH)
+
+    mock_directory_service.assert_called_once_with(MOCK_ADMIN.OAUTH_DECORATOR)
+    mock_watch_users.assert_called_once_with('delete')
+    self.assertEqual(response.status_int, 302)
+    self.assertEqual(sync.CHANNELS_PATH in response.location, True)
+
+  @patch('sync.GoogleDirectoryService.WatchUsers')
+  @patch('sync.GoogleDirectoryService.__init__')
+  def testWatchUserDeleteException(self, mock_directory_service,
+  	                               mock_watch_users):
+    """Test the we fail gracefully if directory service has an error."""
+    # pylint: disable=too-many-arguments
+    fake_status = '404'
+    fake_response = MagicMock(status=fake_status)
+    fake_content = b'some error content'
+    fake_error = errors.HttpError(fake_response, fake_content)
+    mock_directory_service.side_effect = fake_error
+
+    response = self.testapp.get(sync.WATCH_FOR_DELETION_PATH)
+
+    mock_directory_service.assert_called_once_with(MOCK_ADMIN.OAUTH_DECORATOR)
+    mock_watch_users.assert_not_called()
+    self.assertEqual('An error occurred: ' in response, True)
+
+  @patch('sync.GoogleDirectoryService.StopNotifications')
+  @patch('sync.GoogleDirectoryService.__init__')
+  @patch('sync.NotificationChannels.Get')
+  def testUnsubscribeHandler(self, mock_get_channel, mock_directory_service,
+  	                         mock_stop_notifications):
+    """Test the unsubscribe handler calls unsubscribe for the given channel."""
+    # pylint: disable=too-many-arguments
+    fake_channel = MagicMock()
+    mock_get_channel.return_value = fake_channel
+    mock_directory_service.return_value = None
+
+    response = self.testapp.get(sync.UNSUBSCRIBE_PATH + '?id=%s' % FAKE_UUID)
+
+    mock_get_channel.assert_called_once_with(int(FAKE_UUID))
+    mock_directory_service.assert_called_once_with(MOCK_ADMIN.OAUTH_DECORATOR)
+    mock_stop_notifications.assert_called_once_with(fake_channel)
+    self.assertEqual(response.status_int, 302)
+    self.assertEqual(sync.CHANNELS_PATH in response.location, True)
+
+  @patch('sync.GoogleDirectoryService.StopNotifications')
+  @patch('sync.GoogleDirectoryService.__init__')
+  @patch('sync.NotificationChannels.Get')
+  def testUnsubscribeException(self, mock_get_channel, mock_directory_service,
+  	                           mock_stop_notifications):
+    """Test the we fail gracefully if directory service has an error."""
+    # pylint: disable=too-many-arguments
+    fake_channel = MagicMock()
+    mock_get_channel.return_value = fake_channel
+    fake_status = '404'
+    fake_response = MagicMock(status=fake_status)
+    fake_content = b'some error content'
+    fake_error = errors.HttpError(fake_response, fake_content)
+    mock_directory_service.side_effect = fake_error
+
+    response = self.testapp.get(sync.UNSUBSCRIBE_PATH + '?id=%s' % FAKE_UUID)
+
+    mock_get_channel.assert_called_once_with(int(FAKE_UUID))
+    mock_directory_service.assert_called_once_with(MOCK_ADMIN.OAUTH_DECORATOR)
+    mock_stop_notifications.assert_not_called()
+    self.assertEqual('An error occurred: ' in response, True)
+
+  @patch('sync.Notification.GetAll')
+  def testRenderNotifications(self, mock_get_all):
+    """Test notifications from the datastore are rendered as in the html."""
+    fake_notification = MagicMock(state=FAKE_STATE, number=FAKE_NUMBER,
+                                  uuid=FAKE_UUID, email=FAKE_EMAIL)
+    fake_notifications = [fake_notification]
+    mock_get_all.return_value = fake_notifications
+
+    notification_template = sync._RenderNotificationsTemplate()
+
+    mock_get_all.assert_called_once_with()
+    self.assertEquals('View Notification Channels' in notification_template,
+     True)
+    self.assertEquals('Number' in notification_template, True)
+    self.assertEquals('State' in notification_template, True)
+    self.assertEquals('Id' in notification_template, True)
+    self.assertEquals('Email' in notification_template, True)
+    self.assertEquals(FAKE_NUMBER in notification_template, True)
+    self.assertEquals(FAKE_STATE in notification_template, True)
+    self.assertEquals(FAKE_UUID in notification_template, True)
+    self.assertEquals(FAKE_EMAIL in notification_template, True)
+
+  @patch('sync.NotificationChannels.GetAll')
+  def testRenderChannels(self, mock_get_all):
+    """Test channels from the datastore are rendered as in the html."""
+    fake_channel = MagicMock(event=FAKE_EVENT, channel_id=FAKE_CHANNEL_ID,
+                             resource_id=FAKE_RESOURCE_ID)
+    fake_channels = [fake_channel]
+    mock_get_all.return_value = fake_channels
+
+    channels_template = sync._RenderChannelsListTemplate()
+
+    mock_get_all.assert_called_once_with()
+    self.assertEquals('View Notifications' in channels_template, True)
+    self.assertEquals('Channel ID: ' in channels_template, True)
+    self.assertEquals('Resource ID: ' in channels_template, True)
+    self.assertEquals(FAKE_EVENT in channels_template, True)
+    self.assertEquals(FAKE_CHANNEL_ID in channels_template, True)
+    self.assertEquals(FAKE_RESOURCE_ID in channels_template, True)

--- a/sync_test.py
+++ b/sync_test.py
@@ -46,11 +46,11 @@ class UserTest(unittest.TestCase):
     self.assertEqual(sync.SYNC_RELATIVE_PATH, '/sync')
     self.assertEqual(sync.CHANNELS_PATH, sync.SYNC_RELATIVE_PATH + '/channels')
     self.assertEqual(sync.NOTIFICATIONS_PATH,
-    	               sync.SYNC_RELATIVE_PATH + '/notifications')
+                     sync.SYNC_RELATIVE_PATH + '/notifications')
     self.assertEqual(sync.WATCH_FOR_DELETION_PATH,
-    	               sync.SYNC_RELATIVE_PATH + '/delete')
+                     sync.SYNC_RELATIVE_PATH + '/delete')
     self.assertEqual(sync.UNSUBSCRIBE_PATH,
-    	               sync.SYNC_RELATIVE_PATH + '/unsubscribe')
+                     sync.SYNC_RELATIVE_PATH + '/unsubscribe')
 
   @patch('sync.Notification.Insert')
   def testPushNotificationHandler(self, mock_insert):
@@ -165,6 +165,9 @@ class UserTest(unittest.TestCase):
   @patch('sync.Notification.GetAll')
   def testRenderNotifications(self, mock_get_all):
     """Test notifications from the datastore are rendered as in the html."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     fake_notification = MagicMock(state=FAKE_STATE, number=FAKE_NUMBER,
                                   uuid=FAKE_UUID, email=FAKE_EMAIL)
     fake_notifications = [fake_notification]
@@ -187,6 +190,9 @@ class UserTest(unittest.TestCase):
   @patch('sync.NotificationChannels.GetAll')
   def testRenderChannels(self, mock_get_all):
     """Test channels from the datastore are rendered as in the html."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     fake_channel = MagicMock(event=FAKE_EVENT, channel_id=FAKE_CHANNEL_ID,
                              resource_id=FAKE_RESOURCE_ID)
     fake_channels = [fake_channel]

--- a/sync_test.py
+++ b/sync_test.py
@@ -123,7 +123,7 @@ class UserTest(unittest.TestCase):
 
   @patch('sync.GoogleDirectoryService.StopNotifications')
   @patch('sync.GoogleDirectoryService.__init__')
-  @patch('sync.NotificationChannels.Get')
+  @patch('sync.NotificationChannel.Get')
   def testUnsubscribeHandler(self, mock_get_channel, mock_directory_service,
                              mock_stop_notifications):
     """Test the unsubscribe handler calls unsubscribe for the given channel."""
@@ -142,7 +142,7 @@ class UserTest(unittest.TestCase):
 
   @patch('sync.GoogleDirectoryService.StopNotifications')
   @patch('sync.GoogleDirectoryService.__init__')
-  @patch('sync.NotificationChannels.Get')
+  @patch('sync.NotificationChannel.Get')
   def testUnsubscribeException(self, mock_get_channel, mock_directory_service,
                                mock_stop_notifications):
     """Test the we fail gracefully if directory service has an error."""
@@ -187,7 +187,7 @@ class UserTest(unittest.TestCase):
     self.assertEquals(FAKE_UUID in notification_template, True)
     self.assertEquals(FAKE_EMAIL in notification_template, True)
 
-  @patch('sync.NotificationChannels.GetAll')
+  @patch('sync.NotificationChannel.GetAll')
   def testRenderChannels(self, mock_get_all):
     """Test channels from the datastore are rendered as in the html."""
     # Disabling the protected access check here intentionally so we can test a

--- a/sync_test.py
+++ b/sync_test.py
@@ -3,10 +3,7 @@ from mock import MagicMock
 from mock import patch
 import sys
 
-from datastore import Notification
-from datastore import NotificationChannels
 from googleapiclient import errors
-from google.appengine.ext import ndb
 import json
 
 import unittest
@@ -49,11 +46,11 @@ class UserTest(unittest.TestCase):
     self.assertEqual(sync.SYNC_RELATIVE_PATH, '/sync')
     self.assertEqual(sync.CHANNELS_PATH, sync.SYNC_RELATIVE_PATH + '/channels')
     self.assertEqual(sync.NOTIFICATIONS_PATH,
-    	sync.SYNC_RELATIVE_PATH + '/notifications')
+    	               sync.SYNC_RELATIVE_PATH + '/notifications')
     self.assertEqual(sync.WATCH_FOR_DELETION_PATH,
-    	sync.SYNC_RELATIVE_PATH + '/delete')
+    	               sync.SYNC_RELATIVE_PATH + '/delete')
     self.assertEqual(sync.UNSUBSCRIBE_PATH,
-    	sync.SYNC_RELATIVE_PATH + '/unsubscribe')
+    	               sync.SYNC_RELATIVE_PATH + '/unsubscribe')
 
   @patch('sync.Notification.Insert')
   def testPushNotificationHandler(self, mock_insert):
@@ -67,10 +64,10 @@ class UserTest(unittest.TestCase):
     headers['X-Goog-Message-Number'] = FAKE_NUMBER
 
     response = self.testapp.post(sync.RECEIVE_NOTIFICATIONS_PATH, json_body,
-    	                           headers)
+                                 headers)
 
     mock_insert.assert_called_once_with(state=FAKE_STATE, number=FAKE_NUMBER,
-    	                                  uuid=FAKE_UUID, email=FAKE_EMAIL)
+                                        uuid=FAKE_UUID, email=FAKE_EMAIL)
     self.assertEqual('Got a notification!' in response, True)
 
   def testDefaultPathHandler(self):
@@ -94,7 +91,7 @@ class UserTest(unittest.TestCase):
   @patch('sync.GoogleDirectoryService.WatchUsers')
   @patch('sync.GoogleDirectoryService.__init__')
   def testWatchUserDeleteHandler(self, mock_directory_service,
-  	                             mock_watch_users):
+                                 mock_watch_users):
     """Test the watch user delete handler calls watch users with delete."""
     # pylint: disable=too-many-arguments
     mock_directory_service.return_value = None
@@ -109,7 +106,7 @@ class UserTest(unittest.TestCase):
   @patch('sync.GoogleDirectoryService.WatchUsers')
   @patch('sync.GoogleDirectoryService.__init__')
   def testWatchUserDeleteException(self, mock_directory_service,
-  	                               mock_watch_users):
+                                   mock_watch_users):
     """Test the we fail gracefully if directory service has an error."""
     # pylint: disable=too-many-arguments
     fake_status = '404'
@@ -128,7 +125,7 @@ class UserTest(unittest.TestCase):
   @patch('sync.GoogleDirectoryService.__init__')
   @patch('sync.NotificationChannels.Get')
   def testUnsubscribeHandler(self, mock_get_channel, mock_directory_service,
-  	                         mock_stop_notifications):
+                             mock_stop_notifications):
     """Test the unsubscribe handler calls unsubscribe for the given channel."""
     # pylint: disable=too-many-arguments
     fake_channel = MagicMock()
@@ -147,7 +144,7 @@ class UserTest(unittest.TestCase):
   @patch('sync.GoogleDirectoryService.__init__')
   @patch('sync.NotificationChannels.Get')
   def testUnsubscribeException(self, mock_get_channel, mock_directory_service,
-  	                           mock_stop_notifications):
+                               mock_stop_notifications):
     """Test the we fail gracefully if directory service has an error."""
     # pylint: disable=too-many-arguments
     fake_channel = MagicMock()
@@ -177,7 +174,7 @@ class UserTest(unittest.TestCase):
 
     mock_get_all.assert_called_once_with()
     self.assertEquals('View Notification Channels' in notification_template,
-     True)
+                      True)
     self.assertEquals('Number' in notification_template, True)
     self.assertEquals('State' in notification_template, True)
     self.assertEquals('Id' in notification_template, True)

--- a/sync_test.py
+++ b/sync_test.py
@@ -17,7 +17,7 @@ def NoOpDecorator(func):
 
 MOCK_ADMIN = MagicMock()
 MOCK_ADMIN.OAUTH_DECORATOR.oauth_required = NoOpDecorator
-MOCK_ADMIN.RequireAppAndDomainAdmin = NoOpDecorator
+MOCK_ADMIN.RequireAppOrDomainAdmin = NoOpDecorator
 sys.modules['admin'] = MOCK_ADMIN
 
 import sync

--- a/templates/notification_channels.html
+++ b/templates/notification_channels.html
@@ -19,7 +19,7 @@
     <paper-card heading="{{ channel.event }}">
       <div class="card-content">
         <p>Channel ID: {{ channel.channel_id }}</p>
-        <p>resource ID: {{ channel.resource_id }}</p>
+        <p>Resource ID: {{ channel.resource_id }}</p>
       </div>
       <div class="card-actions">
         <!-- <a href="{{ BASE_URL }}/sync/unsubscribe?id={{ channel.key.id() }}">

--- a/templates/notification_channels.html
+++ b/templates/notification_channels.html
@@ -1,0 +1,32 @@
+{% extends "templates/base.html" %}
+{% block title %}Notification Channels{% endblock %}
+{% block head %}
+  <link rel="import" href="/bower_components/paper-button/paper-button.html" />
+  <link rel="import" href="/bower_components/paper-card/paper-card.html" />
+{% endblock %}
+{% block body %}
+  <div class="top-buttons">
+    <!-- <a id='watch_for_user_deletion' href="{{ BASE_URL }}/sync/delete">
+      <paper-button raised class="anchor-button">Watch for User Deletion
+        </paper-button></a> -->
+    <a id='view_notifications' href="{{ BASE_URL }}/sync/notifications">
+      <paper-button raised class="anchor-button">View Notifications
+        </paper-button></a>
+      <br />
+  </div>
+  <div id="channels-card-holder">
+    {% for channel in channels %}
+    <paper-card heading="{{ channel.event }}">
+      <div class="card-content">
+        <p>Channel ID: {{ channel.channel_id }}</p>
+        <p>resource ID: {{ channel.resource_id }}</p>
+      </div>
+      <div class="card-actions">
+        <!-- <a href="{{ BASE_URL }}/sync/unsubscribe?id={{ channel.key.id() }}">
+          <paper-button class="anchor-button">Unsubscribe From Channel
+        </paper-button></a> -->
+      </div>
+    </paper-card>
+    {% endfor %}
+  </div>
+{% endblock %}

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -21,7 +21,7 @@
           <th>Number</th>
           <th>State</th>
           <th>Id</th>
-          <th>email</th>
+          <th>Email</th>
         </tr>
       {% for notification in notifications %}
         <tr>

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -1,0 +1,36 @@
+{% extends "templates/base.html" %}
+{% block title %}Notifications{% endblock %}
+{% block head %}
+  <link rel="import" href="/bower_components/paper-button/paper-button.html" />
+  <link rel="import" href="/bower_components/paper-card/paper-card.html" />
+{% endblock %}
+{% block body %}
+  <div class="top-buttons">
+    <!-- <a id='watch_for_user_deletion' href="{{ BASE_URL }}/sync/delete">
+      <paper-button raised class="anchor-button">Watch for User Deletion
+        </paper-button></a> -->
+    <a id='view_notification_channels' href="{{ BASE_URL }}/sync/channels">
+      <paper-button raised class="anchor-button">View Notification Channels
+        </paper-button></a>
+      <br />
+  </div>
+  <paper-card heading="Previous Notifications">
+    <div class="card-content">
+      <table>
+        <tr>
+          <th>Number</th>
+          <th>State</th>
+          <th>Id</th>
+          <th>email</th>
+        </tr>
+      {% for notification in notifications %}
+        <tr>
+          <td>{{ notification.number }}</td>
+          <td>{{ notification.state }}</td>
+          <td>{{ notification.uuid }}</td>
+          <td>{{ notification.email }}</td>
+        </tr>
+      {% endfor %}
+      </table></div>
+  </paper-card>
+{% endblock %}

--- a/user.py
+++ b/user.py
@@ -236,23 +236,22 @@ class AddUsersHandler(webapp2.RequestHandler):
     group_key = self.request.get('group_key')
     user_key = self.request.get('user_key')
     try:
+      directory_service = GoogleDirectoryService(admin.OAUTH_DECORATOR)
+
+      directory_users = []
       if get_all:
-        directory_service = GoogleDirectoryService(
-            admin.OAUTH_DECORATOR)
         directory_users = directory_service.GetUsers()
-        self.response.write(_RenderAddUsersTemplate(directory_users))
       elif group_key is not None and group_key is not '':
-        directory_service = GoogleDirectoryService(
-            admin.OAUTH_DECORATOR)
         directory_users = directory_service.GetUsersByGroupKey(group_key)
-        self.response.write(_RenderAddUsersTemplate(directory_users))
       elif user_key is not None and user_key is not '':
-        directory_service = GoogleDirectoryService(
-            admin.OAUTH_DECORATOR)
         directory_users = directory_service.GetUserAsList(user_key)
-        self.response.write(_RenderAddUsersTemplate(directory_users))
-      else:
-        self.response.write(_RenderAddUsersTemplate([]))
+
+      if directory_users != []:
+        directory_service.WatchUsers('delete')
+        directory_service.WatchUsers('makeAdmin')
+        directory_service.WatchUsers('undelete')
+        directory_service.WatchUsers('update')
+      self.response.write(_RenderAddUsersTemplate(directory_users))
     except errors.HttpError as error:
       self.response.write(_RenderAddUsersTemplate([], error))
 

--- a/user_test.py
+++ b/user_test.py
@@ -7,7 +7,6 @@ import base64
 from datastore import User
 from googleapiclient import errors
 from google.appengine.ext import ndb
-import google_directory_service
 import hashlib
 import json
 

--- a/user_test.py
+++ b/user_test.py
@@ -110,30 +110,34 @@ class UserTest(unittest.TestCase):
     mock_render_details.assert_called_once_with(FAKE_USER)
 
   @patch('user._RenderAddUsersTemplate')
+  @patch('google_directory_service.GoogleDirectoryService.WatchUsers')
   @patch('google_directory_service.GoogleDirectoryService.GetUserAsList')
   @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
   @patch('google_directory_service.GoogleDirectoryService.GetUsers')
   @patch('google_directory_service.GoogleDirectoryService.__init__')
   def testAddUsersGetHandlerNoParam(self, mock_ds, mock_get_users,
                                     mock_get_by_key, mock_get_user,
-                                    mock_render):
+                                    mock_watch_users, mock_render):
     # pylint: disable=too-many-arguments
+    mock_ds.return_value = None
     self.testapp.get('/user/add')
 
-    mock_ds.assert_not_called()
+    mock_ds.assert_called_once_with(MOCK_ADMIN.OAUTH_DECORATOR)
     mock_get_users.assert_not_called()
     mock_get_user.assert_not_called()
     mock_get_by_key.assert_not_called()
+    mock_watch_users.assert_not_called()
     mock_render.assert_called_once_with([])
 
   @patch('user._RenderAddUsersTemplate')
+  @patch('google_directory_service.GoogleDirectoryService.WatchUsers')
   @patch('google_directory_service.GoogleDirectoryService.GetUserAsList')
   @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
   @patch('google_directory_service.GoogleDirectoryService.GetUsers')
-  @patch.object(google_directory_service.GoogleDirectoryService, '__init__')
+  @patch('google_directory_service.GoogleDirectoryService.__init__')
   def testAddUsersGetHandlerWithGroup(self, mock_ds, mock_get_users,
                                       mock_get_by_key, mock_get_user,
-                                      mock_render):
+                                      mock_watch_users, mock_render):
     # pylint: disable=too-many-arguments
     mock_ds.return_value = None
     # Email address could refer to group or user
@@ -145,16 +149,21 @@ class UserTest(unittest.TestCase):
     mock_get_user.assert_not_called()
     mock_ds.assert_called_once_with(MOCK_ADMIN.OAUTH_DECORATOR)
     mock_get_by_key.assert_called_once_with(group_key)
+    mock_watch_users.assert_any_call('delete')
+    mock_watch_users.assert_any_call('makeAdmin')
+    mock_watch_users.assert_any_call('undelete')
+    mock_watch_users.assert_any_call('update')
     mock_render.assert_called_once_with(FAKE_USER_ARRAY)
 
   @patch('user._RenderAddUsersTemplate')
+  @patch('google_directory_service.GoogleDirectoryService.WatchUsers')
   @patch('google_directory_service.GoogleDirectoryService.GetUserAsList')
   @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
   @patch('google_directory_service.GoogleDirectoryService.GetUsers')
   @patch('google_directory_service.GoogleDirectoryService.__init__')
   def testAddUsersGetHandlerWithUser(self, mock_ds, mock_get_users,
                                      mock_get_by_key, mock_get_user,
-                                     mock_render):
+                                     mock_watch_users, mock_render):
     # pylint: disable=too-many-arguments
     mock_ds.return_value = None
     # Email address could refer to group or user
@@ -166,16 +175,21 @@ class UserTest(unittest.TestCase):
     mock_get_by_key.assert_not_called()
     mock_ds.assert_called_once_with(MOCK_ADMIN.OAUTH_DECORATOR)
     mock_get_user.assert_called_once_with(user_key)
+    mock_watch_users.assert_any_call('delete')
+    mock_watch_users.assert_any_call('makeAdmin')
+    mock_watch_users.assert_any_call('undelete')
+    mock_watch_users.assert_any_call('update')
     mock_render.assert_called_once_with(FAKE_USER_ARRAY)
 
   @patch('user._RenderAddUsersTemplate')
+  @patch('google_directory_service.GoogleDirectoryService.WatchUsers')
   @patch('google_directory_service.GoogleDirectoryService.GetUserAsList')
   @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
   @patch('google_directory_service.GoogleDirectoryService.GetUsers')
   @patch('google_directory_service.GoogleDirectoryService.__init__')
   def testAddUsersGetHandlerWithAll(self, mock_ds, mock_get_users,
                                     mock_get_by_key, mock_get_user,
-                                    mock_render):
+                                    mock_watch_users, mock_render):
     # pylint: disable=too-many-arguments
     mock_ds.return_value = None
     mock_get_users.return_value = FAKE_USER_ARRAY
@@ -185,16 +199,21 @@ class UserTest(unittest.TestCase):
     mock_get_user.assert_not_called()
     mock_ds.assert_called_once_with(MOCK_ADMIN.OAUTH_DECORATOR)
     mock_get_users.assert_called_once_with()
+    mock_watch_users.assert_any_call('delete')
+    mock_watch_users.assert_any_call('makeAdmin')
+    mock_watch_users.assert_any_call('undelete')
+    mock_watch_users.assert_any_call('update')
     mock_render.assert_called_once_with(FAKE_USER_ARRAY)
 
   @patch('user._RenderAddUsersTemplate')
+  @patch('google_directory_service.GoogleDirectoryService.WatchUsers')
   @patch('google_directory_service.GoogleDirectoryService.GetUserAsList')
   @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
   @patch('google_directory_service.GoogleDirectoryService.GetUsers')
   @patch('google_directory_service.GoogleDirectoryService.__init__')
   def testAddUsersGetHandlerWithError(self, mock_ds, mock_get_users,
                                       mock_get_by_key, mock_get_user,
-                                      mock_render):
+                                      mock_watch_users, mock_render):
     # pylint: disable=too-many-arguments
     fake_status = '404'
     fake_response = MagicMock(status=fake_status)
@@ -208,6 +227,7 @@ class UserTest(unittest.TestCase):
     mock_get_by_key.assert_not_called()
     mock_get_user.assert_not_called()
     mock_get_users.assert_not_called()
+    mock_watch_users.assert_not_called()
     mock_render.assert_called_once_with([], fake_error)
 
   @patch('user.User.InsertUsers')


### PR DESCRIPTION
This creates two new datastore entities: Notification and NotificationChannels.

Currently, when we receive a notification, we simply log it in the datastore. I wasn't sure if we wanted to go all out and actually respect these notifications yet, so I kept it simple to start. Similarly, when we subscribe for a channel of notifications, the metadata for that channel is stored in the datastore for reference and so that we can unsubscribe later on if necessary.

The sync module has several handlers for accepting push notifications, viewing the notifications and channels in the datastore, subscribing for notifications, and unsubscribing from notifications. In order to receive notifications, the receiving address must use https. However, we cannot use oauth on that channel as directory services does not perform an auth before sending the message. Thus, the handler receiving these notifications is insecure and unauthenticated. I separated this handler out under /receive, whereas all other handler are under /sync which does require security and authentication.

To make this process more secure, in the future I can add support for generating a random token on the server and passing that to directory services when we subscribe. Directory services will then include that token in a header when sending post notifications. This isn't as good as real authentication, but it is at least something that would make it harder for a malicious user to spoof.

Finally, I added several docstrings to the datastore module while implementing tests for this to help incrementally clean that up. Overall, this has improved our landscape.io health check to 89% at last check which should only continue to rise.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server/56)
<!-- Reviewable:end -->
