### PR TITLE
Make the paths to be shareable between app code and test code.

### DIFF
--- a/appengine_config.py
+++ b/appengine_config.py
@@ -1,5 +1,6 @@
 """Custom configurations for Google App Engine."""
 
+from config import PATHS
 from google.appengine.api import app_identity
 from google.appengine.ext import vendor
 import jinja2
@@ -19,6 +20,9 @@ JINJA_ENVIRONMENT = jinja2.Environment(
 JINJA_ENVIRONMENT.globals['xsrf_token'] = xsrf.XSRFToken()
 HOST = str(app_identity.get_default_version_hostname())
 JINJA_ENVIRONMENT.globals['BASE_URL'] = ('https://' + HOST)
+
+for key,value in PATHS.iteritems():
+  JINJA_ENVIRONMENT.globals[key] = value
 
 # Add any libraries installed in the "lib" folder.
 vendor.add('lib')

--- a/config.py
+++ b/config.py
@@ -1,5 +1,4 @@
 LANDING_PAGE_PATH = '/'
-
 USER_PAGE_PATH = '/user'
 
 USER_ADD_PATH = '/user/add'

--- a/config.py
+++ b/config.py
@@ -1,0 +1,10 @@
+LANDING_PAGE_PATH = '/'
+
+USER_PAGE_PATH = '/user'
+
+USER_ADD_PATH = '/user/add'
+USER_DELETE_PATH = '/user/delete'
+USER_DETAILS_PATH = '/user/details'
+USER_GET_INVITE_CODE_PATH = '/user/getInviteCode'
+USER_GET_NEW_KEY_PAIR_PATH = '/user/getNewKeyPair'
+USER_TOGGLE_REVOKED_PATH = '/user/toggleRevoked'

--- a/config.py
+++ b/config.py
@@ -1,11 +1,14 @@
 """App configs to simplify the importing for tests and mocks."""
 
-LANDING_PAGE_PATH = '/'
-USER_PAGE_PATH = '/user'
+PATHS = {
+  'landing_page_path': '/',
+  'user_page_path': '/user',
 
-USER_ADD_PATH = '/user/add'
-USER_DELETE_PATH = '/user/delete'
-USER_DETAILS_PATH = '/user/details'
-USER_GET_INVITE_CODE_PATH = '/user/getInviteCode'
-USER_GET_NEW_KEY_PAIR_PATH = '/user/getNewKeyPair'
-USER_TOGGLE_REVOKED_PATH = '/user/toggleRevoked'
+  'user_add_path': '/user/add',
+  'user_delete_path': '/user/delete',
+  'user_details_path': '/user/details',
+  'user_get_invite_code_path': '/user/getInviteCode',
+  'user_get_new_key_pair_path': '/user/getNewKeyPair',
+  'user_toggle_revoked_path': '/user/toggleRevoked',
+}
+

--- a/config.py
+++ b/config.py
@@ -1,3 +1,5 @@
+"""App configs to simplify the importing for tests and mocks."""
+
 LANDING_PAGE_PATH = '/'
 USER_PAGE_PATH = '/user'
 

--- a/templates/user.html
+++ b/templates/user.html
@@ -8,7 +8,7 @@
 {% endblock %}
 {% block body %}
   <div class="top-buttons">
-    <a id='add_users' href="{{ BASE_URL }}/user/add">
+    <a id='add_users' href="{{BASE_URL}}{{ user_add_path }}">
       <paper-button raised class="anchor-button">Add Users</paper-button></a>
       <br />
   </div>
@@ -17,7 +17,7 @@
       <p>Click a user below to view more details.</p>
       <paper-listbox>
       {% for key, email in user_payloads.iteritems() %}
-        <a href="{{ BASE_URL }}/user/details?key={{ key }}">
+        <a href="{{ BASE_URL }}{{ user_details_path }}?key={{ key }}">
           <paper-item>{{ email }}</paper-item></a>
       {% endfor %}
       </paper-listbox></div>

--- a/templates/user_details.html
+++ b/templates/user_details.html
@@ -23,16 +23,16 @@
         <iron-collapse id="collapse-pub"><div>{{ user.public_key }}</div></iron-collapse>
       </div>
       <div class="card-actions">
-        <a href="{{ BASE_URL }}/user/delete?key={{ key }}">
+        <a href="{{ BASE_URL }}{{ user_delete_path }}?key={{ key }}">
           <paper-button raised class="anchor-button">Delete User
         </paper-button></a>
-        <a href="{{ BASE_URL }}/user/getInviteCode?key={{ key }}">
+        <a href="{{ BASE_URL }}{{ user_get_invite_code_path }}?key={{ key }}">
           <paper-button raised class="anchor-button">Get Invite Code
         </paper-button></a>
-        <a href="{{ BASE_URL }}/user/getNewKeyPair?key={{ key }}">
+        <a href="{{ BASE_URL }}{{ user_get_new_key_pair_path }}?key={{ key }}">
           <paper-button raised class="anchor-button">Rotate Key Pair
         </paper-button></a>
-        <a href="{{ BASE_URL }}/user/toggleRevoked?key={{ key }}">
+        <a href="{{ BASE_URL }}{{ user_toggle_revoked_path }}?key={{ key }}">
           <paper-button raised class="anchor-button">Revoke/Unrevoke Access
         </paper-button></a>
       </div>

--- a/tests/ui/test_config.py
+++ b/tests/ui/test_config.py
@@ -5,13 +5,6 @@ import sys
 sys.path.append('../..')
 
 # pylint: disable=unused-import
-from config import LANDING_PAGE_PATH
-from config import USER_ADD_PATH
-from config import USER_DELETE_PATH
-from config import USER_DETAILS_PATH
-from config import USER_GET_INVITE_CODE_PATH
-from config import USER_GET_NEW_KEY_PAIR_PATH
-from config import USER_PAGE_PATH
-from config import USER_TOGGLE_REVOKED_PATH
+from config import PATHS
 
 CHROME_DRIVER_LOCATION = '../../lib/chromedriver'

--- a/tests/ui/test_config.py
+++ b/tests/ui/test_config.py
@@ -1,3 +1,16 @@
 """Constant for locating the chrome driver and changing in one place."""
 
+# Hack to make the app directory to be visible here.
+import sys
+sys.path.append('../..')
+
+from config import LANDING_PAGE_PATH
+from config import USER_PAGE_PATH
+from config import USER_DELETE_PATH
+from config import USER_GET_INVITE_CODE_PATH
+from config import USER_GET_NEW_KEY_PAIR_PATH
+from config import USER_ADD_PATH
+from config import USER_TOGGLE_REVOKED_PATH
+from config import USER_DETAILS_PATH
+
 CHROME_DRIVER_LOCATION = '../../lib/chromedriver'

--- a/tests/ui/test_config.py
+++ b/tests/ui/test_config.py
@@ -1,4 +1,4 @@
-"""Configs for the ui tests ."""
+"""Configs for the ui tests."""
 
 # Hack to make the app directory to be visible here.
 import sys

--- a/tests/ui/test_config.py
+++ b/tests/ui/test_config.py
@@ -6,12 +6,12 @@ sys.path.append('../..')
 
 # pylint: disable=unused-import
 from config import LANDING_PAGE_PATH
-from config import USER_PAGE_PATH
+from config import USER_ADD_PATH
 from config import USER_DELETE_PATH
+from config import USER_DETAILS_PATH
 from config import USER_GET_INVITE_CODE_PATH
 from config import USER_GET_NEW_KEY_PAIR_PATH
-from config import USER_ADD_PATH
+from config import USER_PAGE_PATH
 from config import USER_TOGGLE_REVOKED_PATH
-from config import USER_DETAILS_PATH
 
 CHROME_DRIVER_LOCATION = '../../lib/chromedriver'

--- a/tests/ui/test_config.py
+++ b/tests/ui/test_config.py
@@ -4,6 +4,7 @@
 import sys
 sys.path.append('../..')
 
+# pylint: disable=unused-import
 from config import LANDING_PAGE_PATH
 from config import USER_PAGE_PATH
 from config import USER_DELETE_PATH

--- a/tests/ui/test_config.py
+++ b/tests/ui/test_config.py
@@ -1,4 +1,4 @@
-"""Constant for locating the chrome driver and changing in one place."""
+"""Configs for the ui tests ."""
 
 # Hack to make the app directory to be visible here.
 import sys

--- a/tests/ui/user_page_test.py
+++ b/tests/ui/user_page_test.py
@@ -4,6 +4,7 @@ import unittest
 from base_test import BaseTest
 from login_page import LoginPage
 from test_config import CHROME_DRIVER_LOCATION
+from test_config import USER_PAGE_PATH
 from user_page import UserPage
 
 from selenium import webdriver
@@ -22,7 +23,7 @@ class UserPageTest(BaseTest):
     """Test the user page."""
     add_users = (u'Add Users').upper()
 
-    self.driver.get(self.args.server_url + '/user#')
+    self.driver.get(self.args.server_url + USER_PAGE_PATH)
     user_page = UserPage(self.driver)
     self.assertEquals(add_users, user_page.GetAddUserLink().text)
     self.assertIsNotNone(user_page.GetSidebar())

--- a/tests/ui/user_page_test.py
+++ b/tests/ui/user_page_test.py
@@ -4,7 +4,7 @@ import unittest
 from base_test import BaseTest
 from login_page import LoginPage
 from test_config import CHROME_DRIVER_LOCATION
-from test_config import USER_PAGE_PATH
+from test_config import PATHS
 from user_page import UserPage
 
 from selenium import webdriver
@@ -23,7 +23,7 @@ class UserPageTest(BaseTest):
     """Test the user page."""
     add_users = (u'Add Users').upper()
 
-    self.driver.get(self.args.server_url + USER_PAGE_PATH)
+    self.driver.get(self.args.server_url + PATHS['user_page_path'])
     user_page = UserPage(self.driver)
     self.assertEquals(add_users, user_page.GetAddUserLink().text)
     self.assertIsNotNone(user_page.GetSidebar())

--- a/user.py
+++ b/user.py
@@ -4,14 +4,7 @@ import admin
 from appengine_config import JINJA_ENVIRONMENT
 from ast import literal_eval
 import base64
-from config import LANDING_PAGE_PATH
-from config import USER_PAGE_PATH
-from config import USER_DELETE_PATH
-from config import USER_GET_INVITE_CODE_PATH
-from config import USER_GET_NEW_KEY_PAIR_PATH
-from config import USER_ADD_PATH
-from config import USER_TOGGLE_REVOKED_PATH
-from config import USER_DETAILS_PATH
+from config import PATHS
 from datastore import DomainVerification
 from datastore import ProxyServer
 from datastore import User
@@ -274,7 +267,7 @@ class AddUsersHandler(webapp2.RequestHandler):
       decoded_user = literal_eval(user)
       decoded_users.append(decoded_user)
     User.InsertUsers(decoded_users)
-    self.redirect(USER_PAGE_PATH)
+    self.redirect(PATHS['user_page_path'])
 
 
 class ToggleKeyRevokedHandler(webapp2.RequestHandler):
@@ -309,14 +302,14 @@ class GetUserDetailsHandler(webapp2.RequestHandler):
 
 
 APP = webapp2.WSGIApplication([
-    (LANDING_PAGE_PATH, LandingPageHandler),
-    (USER_PAGE_PATH, ListUsersHandler),
-    (USER_DELETE_PATH, DeleteUserHandler),
-    (USER_GET_INVITE_CODE_PATH, GetInviteCodeHandler),
-    (USER_GET_NEW_KEY_PAIR_PATH, GetNewKeyPairHandler),
-    (USER_ADD_PATH, AddUsersHandler),
-    (USER_TOGGLE_REVOKED_PATH, ToggleKeyRevokedHandler),
-    (USER_DETAILS_PATH, GetUserDetailsHandler),
+    (PATHS['landing_page_path'], LandingPageHandler),
+    (PATHS['user_page_path'], ListUsersHandler),
+    (PATHS['user_delete_path'], DeleteUserHandler),
+    (PATHS['user_get_invite_code_path'], GetInviteCodeHandler),
+    (PATHS['user_get_new_key_pair_path'], GetNewKeyPairHandler),
+    (PATHS['user_add_path'], AddUsersHandler),
+    (PATHS['user_toggle_revoked_path'], ToggleKeyRevokedHandler),
+    (PATHS['user_details_path'], GetUserDetailsHandler),
     (admin.OAUTH_DECORATOR.callback_path,
      admin.OAUTH_DECORATOR.callback_handler()),
 ], debug=True)

--- a/user.py
+++ b/user.py
@@ -4,6 +4,14 @@ import admin
 from appengine_config import JINJA_ENVIRONMENT
 from ast import literal_eval
 import base64
+from config import LANDING_PAGE_PATH
+from config import USER_PAGE_PATH
+from config import USER_DELETE_PATH
+from config import USER_GET_INVITE_CODE_PATH
+from config import USER_GET_NEW_KEY_PAIR_PATH
+from config import USER_ADD_PATH
+from config import USER_TOGGLE_REVOKED_PATH
+from config import USER_DETAILS_PATH
 from datastore import DomainVerification
 from datastore import ProxyServer
 from datastore import User
@@ -266,7 +274,7 @@ class AddUsersHandler(webapp2.RequestHandler):
       decoded_user = literal_eval(user)
       decoded_users.append(decoded_user)
     User.InsertUsers(decoded_users)
-    self.redirect('/user')
+    self.redirect(USER_PAGE_PATH)
 
 
 class ToggleKeyRevokedHandler(webapp2.RequestHandler):
@@ -301,14 +309,14 @@ class GetUserDetailsHandler(webapp2.RequestHandler):
 
 
 APP = webapp2.WSGIApplication([
-    ('/', LandingPageHandler),
-    ('/user', ListUsersHandler),
-    ('/user/delete', DeleteUserHandler),
-    ('/user/getInviteCode', GetInviteCodeHandler),
-    ('/user/getNewKeyPair', GetNewKeyPairHandler),
-    ('/user/add', AddUsersHandler),
-    ('/user/toggleRevoked', ToggleKeyRevokedHandler),
-    ('/user/details', GetUserDetailsHandler),
+    (LANDING_PAGE_PATH, LandingPageHandler),
+    (USER_PAGE_PATH, ListUsersHandler),
+    (USER_DELETE_PATH, DeleteUserHandler),
+    (USER_GET_INVITE_CODE_PATH, GetInviteCodeHandler),
+    (USER_GET_NEW_KEY_PAIR_PATH, GetNewKeyPairHandler),
+    (USER_ADD_PATH, AddUsersHandler),
+    (USER_TOGGLE_REVOKED_PATH, ToggleKeyRevokedHandler),
+    (USER_DETAILS_PATH, GetUserDetailsHandler),
     (admin.OAUTH_DECORATOR.callback_path,
      admin.OAUTH_DECORATOR.callback_handler()),
 ], debug=True)

--- a/user_test.py
+++ b/user_test.py
@@ -4,14 +4,7 @@ from mock import patch
 import sys
 
 import base64
-from config import LANDING_PAGE_PATH
-from config import USER_ADD_PATH
-from config import USER_DELETE_PATH
-from config import USER_DETAILS_PATH
-from config import USER_GET_INVITE_CODE_PATH
-from config import USER_GET_NEW_KEY_PAIR_PATH
-from config import USER_PAGE_PATH
-from config import USER_TOGGLE_REVOKED_PATH
+from config import PATHS
 from datastore import User
 from googleapiclient import errors
 from google.appengine.ext import ndb
@@ -72,19 +65,19 @@ class UserTest(unittest.TestCase):
 
   @patch('user._RenderLandingTemplate')
   def testLandingPageHandler(self, mock_landing_template):
-    self.testapp.get(LANDING_PAGE_PATH)
+    self.testapp.get(PATHS['landing_page_path'])
     mock_landing_template.assert_called_once_with()
 
   @patch('user._RenderUserListTemplate')
   def testListUsersHandler(self, mock_user_template):
-    self.testapp.get(USER_PAGE_PATH)
+    self.testapp.get(PATHS['user_page_path'])
     mock_user_template.assert_called_once_with()
 
   @patch('user.User.DeleteByKey')
   @patch('user._RenderUserListTemplate')
   def testDeleteUserHandler(self, mock_user_template,
                             mock_delete_user):
-    self.testapp.get(USER_DELETE_PATH + '?key=' + FAKE_DS_KEY)
+    self.testapp.get(PATHS['user_delete_path'] + '?key=' + FAKE_DS_KEY)
     mock_delete_user.assert_called_once_with(FAKE_DS_KEY)
     mock_user_template.assert_called_once_with()
 
@@ -97,7 +90,7 @@ class UserTest(unittest.TestCase):
     fake_invite_code = 'base64EncodedBlob'
     mock_make_invite_code.return_value = fake_invite_code
 
-    self.testapp.get(USER_GET_INVITE_CODE_PATH + '?key=' + FAKE_DS_KEY)
+    self.testapp.get(PATHS['user_get_invite_code_path'] + '?key=' + FAKE_DS_KEY)
 
     mock_get_user.assert_called_once_with(FAKE_DS_KEY)
     mock_make_invite_code.assert_called_once_with(FAKE_USER)
@@ -110,7 +103,8 @@ class UserTest(unittest.TestCase):
                                mock_render_details):
     mock_get_by_key.return_value = FAKE_USER
 
-    self.testapp.get(USER_GET_NEW_KEY_PAIR_PATH + '?key=' + FAKE_DS_KEY)
+    self.testapp.get(
+        PATHS['user_get_new_key_pair_path'] + '?key=' + FAKE_DS_KEY)
 
     mock_update.assert_called_once_with(FAKE_DS_KEY)
     mock_get_by_key.assert_called_once_with(FAKE_DS_KEY)
@@ -127,7 +121,7 @@ class UserTest(unittest.TestCase):
                                     mock_watch_users, mock_render):
     # pylint: disable=too-many-arguments
     mock_ds.return_value = None
-    self.testapp.get(USER_ADD_PATH)
+    self.testapp.get(PATHS['user_add_path'])
 
     mock_ds.assert_called_once_with(MOCK_ADMIN.OAUTH_DECORATOR)
     mock_get_users.assert_not_called()
@@ -150,7 +144,7 @@ class UserTest(unittest.TestCase):
     # Email address could refer to group or user
     group_key = 'foo@bar.mybusiness.com'
     mock_get_by_key.return_value = FAKE_USER_ARRAY
-    self.testapp.get(USER_ADD_PATH + '?group_key=' + group_key)
+    self.testapp.get(PATHS['user_add_path'] + '?group_key=' + group_key)
 
     mock_get_users.assert_not_called()
     mock_get_user.assert_not_called()
@@ -176,7 +170,7 @@ class UserTest(unittest.TestCase):
     # Email address could refer to group or user
     user_key = 'foo@bar.mybusiness.com'
     mock_get_user.return_value = FAKE_USER_ARRAY
-    self.testapp.get(USER_ADD_PATH + '?user_key=' + user_key)
+    self.testapp.get(PATHS['user_add_path'] + '?user_key=' + user_key)
 
     mock_get_users.assert_not_called()
     mock_get_by_key.assert_not_called()
@@ -200,7 +194,7 @@ class UserTest(unittest.TestCase):
     # pylint: disable=too-many-arguments
     mock_ds.return_value = None
     mock_get_users.return_value = FAKE_USER_ARRAY
-    self.testapp.get(USER_ADD_PATH + '?get_all=true')
+    self.testapp.get(PATHS['user_add_path'] + '?get_all=true')
 
     mock_get_by_key.assert_not_called()
     mock_get_user.assert_not_called()
@@ -228,7 +222,7 @@ class UserTest(unittest.TestCase):
     fake_error = errors.HttpError(fake_response, fake_content)
     mock_ds.side_effect = fake_error
     mock_get_users.return_value = FAKE_USER_ARRAY
-    self.testapp.get(USER_ADD_PATH + '?get_all=true')
+    self.testapp.get(PATHS['user_add_path'] + '?get_all=true')
 
     mock_ds.assert_called_once_with(MOCK_ADMIN.OAUTH_DECORATOR)
     mock_get_by_key.assert_not_called()
@@ -251,11 +245,11 @@ class UserTest(unittest.TestCase):
     user_array.append(user_1)
     user_array.append(user_2)
     data = '?selected_user={0}&selected_user={1}'.format(user_1, user_2)
-    response = self.testapp.post(USER_ADD_PATH + data)
+    response = self.testapp.post(PATHS['user_add_path'] + data)
 
     mock_insert.assert_called_once_with(user_array)
     self.assertEqual(response.status_int, 302)
-    self.assertTrue(USER_PAGE_PATH in response.location)
+    self.assertTrue(PATHS['user_page_path'] in response.location)
 
   @patch('user._RenderUserDetailsTemplate')
   @patch('user.User.GetByKey')
@@ -264,7 +258,7 @@ class UserTest(unittest.TestCase):
                                   mock_get_by_key, mock_render_details):
     mock_get_by_key.return_value = FAKE_USER
 
-    self.testapp.get(USER_TOGGLE_REVOKED_PATH + '?key=' + FAKE_DS_KEY)
+    self.testapp.get(PATHS['user_toggle_revoked_path'] + '?key=' + FAKE_DS_KEY)
 
     mock_toggle_key_revoked.assert_called_once_with(FAKE_DS_KEY)
     mock_get_by_key.assert_called_once_with(FAKE_DS_KEY)
@@ -275,7 +269,7 @@ class UserTest(unittest.TestCase):
   def testGetUserDetailsHandler(self, mock_get_by_key, mock_render_details):
     mock_get_by_key.return_value = FAKE_USER
 
-    self.testapp.get(USER_DETAILS_PATH + '?key=' + FAKE_DS_KEY)
+    self.testapp.get(PATHS['user_details_path'] + '?key=' + FAKE_DS_KEY)
 
     mock_get_by_key.assert_called_once_with(FAKE_DS_KEY)
     mock_render_details.assert_called_once_with(FAKE_USER)


### PR DESCRIPTION
Some notes:
- This is just a first step, to see how this looks since it involves a hack.  Will finish the rest if this is cool.

- Need a separate clean file to hold the paths so that it's a simpler import for tests and mocks.  Otherwise, if the path constants are in the app module, the module dependencies will break the tests/mocks.

- There is a necessary import hack to make the paths to be importable from a different directory.  This the simpliest way suggested by stackoverflow.
http://stackoverflow.com/a/4383597/2830207

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server/58)
<!-- Reviewable:end -->
