### PR TITLE
Cleanup Random HTML Problems and Landscape Health Checks

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -49,7 +49,7 @@ def RequireAppAdmin(func):
     """
     user = users.get_current_user()
     AbortIfUserIsNotLoggedIn(self, user)
-    AbortIfUserIsNotApplicationAdmin(self)
+    AbortIfUserNotApplicationAdmin(self)
     return func(self, *args, **kwargs)
 
   return decorate

--- a/admin.py
+++ b/admin.py
@@ -31,7 +31,7 @@ def AbortIfUserIsNotLoggedIn(self, user):
     logging.error('User is not logged in.')
     self.abort(403)
 
-def AbortIfUserIsNotApplicationAdmin(self):
+def AbortIfUserNotApplicationAdmin(self):
   """Check if the user is an application admin and abort if not."""
   if not users.is_current_user_admin():
     logging.error('User is not an application admin.')

--- a/admin.py
+++ b/admin.py
@@ -31,7 +31,7 @@ def AbortIfUserIsNotLoggedIn(self, user):
     logging.error('User is not logged in.')
     self.abort(403)
 
-def AbortIfUserNotApplicationAdmin(self):
+def AbortIfUserIsNotAppAdmin(self):
   """Check if the user is an application admin and abort if not."""
   if not users.is_current_user_admin():
     logging.error('User is not an application admin.')
@@ -49,7 +49,7 @@ def RequireAppAdmin(func):
     """
     user = users.get_current_user()
     AbortIfUserIsNotLoggedIn(self, user)
-    AbortIfUserNotApplicationAdmin(self)
+    AbortIfUserIsNotAppAdmin(self)
     return func(self, *args, **kwargs)
 
   return decorate

--- a/css/custom.css
+++ b/css/custom.css
@@ -6,6 +6,10 @@ paper-card {
   margin-bottom: 16px;
 }
 
+form {
+  max-width: 800px;
+}
+
 .anchor-button {
   color: inherit;
   background-color: inherit;
@@ -15,13 +19,14 @@ paper-card {
   margin-bottom: 16px;
 }
 
+.padding-between-columns td
+{
+  padding: 0 15px 0 15px;
+}
+
 #main-section {
   margin-left: 16px;
   margin-top: 16px;
-}
-
-#setup-form {
-  max-width: 800px;
 }
 
 #proxy-card-holder {
@@ -34,4 +39,8 @@ paper-card {
 
 #channels-card-holder {
   max-width: 600px;
+}
+
+#notifications-card {
+  max-width: 800px;
 }

--- a/datastore_test.py
+++ b/datastore_test.py
@@ -202,6 +202,9 @@ class UserDatastoreTest(DatastoreTest):
   @patch.object(datastore.hashlib, 'sha256')
   def testCreateUser(self, mock_sha, mock_hex, mock_key):
     """Test that a new user entity is created with the associated fields."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     fake_hex_email = '0x12345678'
     mock_hex.return_value = fake_hex_email
     mock_sha.return_value.hexdigest = mock_hex
@@ -225,6 +228,9 @@ class UserDatastoreTest(DatastoreTest):
   @patch.object(datastore.RSA, 'generate')
   def testGenerateKeyPair(self, mock_rsa, mock_exp, mock_pub, mock_encode):
     """Test that a new key pair is created successfully."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     mock_encode.return_value = FAKE_PRIVATE_KEY
     mock_exp.return_value = FAKE_PRIVATE_KEY
     mock_pub.return_value.exportKey = mock_exp

--- a/logout_test.py
+++ b/logout_test.py
@@ -11,10 +11,16 @@ class LogoutTest(unittest.TestCase):
   """Test logout module functionality."""
 
   def setUp(self):
+    """Setup test app on which to call handlers."""
     self.testapp = webtest.TestApp(logout.APP)
 
   @patch('google.appengine.api.users.create_logout_url')
   def testLogoutHandler(self, mock_create_url):
+    """Test that logging out works without auth.
+
+    Also test that users can log back in without looping back through the
+    logout flow.
+    """
     logout_relative_path = '/logout'
     fake_redirect_url = 'foo/bar'
     mock_create_url.return_value = fake_redirect_url

--- a/proxy_server_test.py
+++ b/proxy_server_test.py
@@ -39,20 +39,24 @@ class ProxyServerTest(unittest.TestCase):
   """Test proxy server class functionality."""
 
   def setUp(self):
+    """Setup test app on which to call handlers."""
     self.testapp = webtest.TestApp(proxy_server.APP)
 
   @patch('proxy_server._RenderListProxyServerTemplate')
   def testListProxyServersHandler(self, mock_render_list_template):
+    """Test the list handler displays proxy servers from the datastore."""
     self.testapp.get('/proxyserver/list')
     mock_render_list_template.assert_called_once_with()
 
   @patch('proxy_server._RenderProxyServerFormTemplate')
   def testAddProxyServerGetHandler(self, mock_render_add_template):
+    """Test the add handler displays the add proxy server form."""
     self.testapp.get('/proxyserver/add')
     mock_render_add_template.assert_called_once_with(None)
 
   @patch('datastore.ProxyServer.Insert')
   def testAddProxyServerPostHandler(self, mock_insert):
+    """Test the add handler adds a new proxy server into the datastore."""
     response = self.testapp.post('/proxyserver/add')
 
     mock_insert.assert_called_once_with('', '', '', '')
@@ -62,6 +66,7 @@ class ProxyServerTest(unittest.TestCase):
   @patch('proxy_server._RenderProxyServerFormTemplate')
   @patch('datastore.ProxyServer.Get')
   def testEditProxyServerGetHandler(self, mock_get, mock_render_edit_template):
+    """Test the edit handler prepopulates the proxy server in the form."""
     fake_proxy_server = GetFakeProxyServer()
     mock_get.return_value = fake_proxy_server
     self.testapp.get('/proxyserver/edit?id=' + str(FAKE_ID))
@@ -71,6 +76,7 @@ class ProxyServerTest(unittest.TestCase):
 
   @patch('datastore.ProxyServer.Update')
   def testEditProxyServerPostHandler(self, mock_update):
+    """Test the edit handler updates the proxy server in the datastore."""
     params = {'id': str(FAKE_ID),
               'name': FAKE_NAME,
               'ip_address': FAKE_IP_ADDRESS,
@@ -87,6 +93,7 @@ class ProxyServerTest(unittest.TestCase):
   @patch('datastore.ProxyServer.Delete')
   def testDeleteProxyServerHandler(self, mock_delete,
                                    mock_render_list_template):
+    """Test the delete handler calls to delete the proxy from the datastore."""
     self.testapp.get('/proxyserver/delete?id=' + str(FAKE_ID))
     mock_delete.assert_called_once_with(FAKE_ID)
     mock_render_list_template.assert_called_once_with()
@@ -96,6 +103,7 @@ class ProxyServerTest(unittest.TestCase):
   @patch('datastore.ProxyServer.GetAll')
   def testDistributeKeyHandler(self, mock_get_all, mock_request,
                                mock_make_key_string):
+    """Test the distribute handler calls to put the keys on each proxy."""
     fake_proxy_server = GetFakeProxyServer()
     fake_proxy_servers = [fake_proxy_server]
     mock_get_all.return_value = fake_proxy_servers
@@ -116,6 +124,10 @@ class ProxyServerTest(unittest.TestCase):
         body=fake_key_string)
 
   def testRenderAddProxyServerTemplate(self):
+    """Test the proxy server add form is rendered as in the html."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     add_form = proxy_server._RenderProxyServerFormTemplate(None)
     self.assertTrue('/proxyserver/add' in add_form)
     self.assertFalse('/proxyserver/edit' in add_form)
@@ -123,6 +135,10 @@ class ProxyServerTest(unittest.TestCase):
     self.assertTrue('IP Address' in add_form)
 
   def testRenderEditProxyServerTemplate(self):
+    """Test the proxy server edit form is rendered as in the html."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     fake_proxy_server = GetFakeProxyServer()
     edit_form = proxy_server._RenderProxyServerFormTemplate(fake_proxy_server)
     self.assertFalse('/proxyserver/add' in edit_form)
@@ -136,6 +152,10 @@ class ProxyServerTest(unittest.TestCase):
 
   @patch('datastore.ProxyServer.GetAll')
   def testRenderListProxyServerTemplate(self, mock_get_all):
+    """Test proxy servers from the datastore are rendered as in the html."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     fake_proxy_server = GetFakeProxyServer()
     fake_proxy_servers = [fake_proxy_server]
     mock_get_all.return_value = fake_proxy_servers
@@ -149,6 +169,10 @@ class ProxyServerTest(unittest.TestCase):
 
   @patch('datastore.User.GetAll')
   def testMakeKeyString(self, mock_get_all):
+    """Test that the key string is generated with all non-revoked users."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     fake_emails = ['foo@bar.com', 'bar@baz.com', 'baz@foo.com']
     fake_public_keys = ['123abc', 'def456', '789ghi']
     fake_user_1 = MagicMock(email=fake_emails[0],

--- a/setup_test.py
+++ b/setup_test.py
@@ -39,10 +39,12 @@ class SetupTest(unittest.TestCase):
   """Test setup class functionality."""
 
   def setUp(self):
+    """Setup test app on which to call handlers"""
     self.testapp = webtest.TestApp(setup.APP)
 
   @patch('setup._RenderSetupOAuthClientTemplate')
   def testSetupGetHandler(self, mock_render_oauth_template):
+    """Test get on the setup handler renders the setup form."""
     self.testapp.get('/setup')
     mock_render_oauth_template.assert_called_once_with()
 
@@ -52,6 +54,11 @@ class SetupTest(unittest.TestCase):
   @patch('datastore.OAuth.Flush')
   def testSetupPostAlreadySetHandler(self, mock_flush, mock_oauth_update,
                                      mock_dv_update, mock_get_count):
+    """Test posting after adding users redirects to the main page.
+
+    This also tests that the post in fact works and sets the proper values in
+    the datastore as posted.
+    """
     mock_get_count.return_value = 1
     post_url = ('/setup?client_id={0}&client_secret={1}' +
                 '&dv_content={2}')
@@ -71,6 +78,7 @@ class SetupTest(unittest.TestCase):
   @patch('datastore.OAuth.Flush')
   def testSetupPostNotSetHandler(self, mock_flush, mock_oauth_update,
                                  mock_dv_update, mock_get_count):
+    """Test posting before adding users redirects to the add flow."""
     mock_get_count.return_value = 0
     post_url = ('/setup?client_id={0}&client_secret={1}' +
                 '&dv_content={2}')
@@ -88,6 +96,10 @@ class SetupTest(unittest.TestCase):
   @patch('datastore.DomainVerification.GetOrInsertDefault')
   @patch('datastore.OAuth.GetOrInsertDefault')
   def testRenderSetupTemplate(self, mock_oauth_goi, mock_dv_goi):
+    """Test the setup form is rendered as in the html."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     mock_oauth_goi.return_value.client_id = FAKE_ID
     mock_oauth_goi.return_value.client_secret = FAKE_SECRET
     mock_dv_goi.return_value.content = FAKE_CONTENT

--- a/setup_test.py
+++ b/setup_test.py
@@ -39,7 +39,7 @@ class SetupTest(unittest.TestCase):
   """Test setup class functionality."""
 
   def setUp(self):
-    """Setup test app on which to call handlers"""
+    """Setup test app on which to call handlers."""
     self.testapp = webtest.TestApp(setup.APP)
 
   @patch('setup._RenderSetupOAuthClientTemplate')

--- a/sync_test.py
+++ b/sync_test.py
@@ -107,7 +107,7 @@ class UserTest(unittest.TestCase):
   @patch('sync.GoogleDirectoryService.__init__')
   def testWatchUserDeleteException(self, mock_directory_service,
                                    mock_watch_users):
-    """Test the we fail gracefully if directory service has an error."""
+    """Test that we fail gracefully if directory service has an error."""
     # pylint: disable=too-many-arguments
     fake_status = '404'
     fake_response = MagicMock(status=fake_status)
@@ -145,7 +145,7 @@ class UserTest(unittest.TestCase):
   @patch('sync.NotificationChannel.Get')
   def testUnsubscribeException(self, mock_get_channel, mock_directory_service,
                                mock_stop_notifications):
-    """Test the we fail gracefully if directory service has an error."""
+    """Test that we fail gracefully if directory service has an error."""
     # pylint: disable=too-many-arguments
     fake_channel = MagicMock()
     mock_get_channel.return_value = fake_channel

--- a/templates/add_user.html
+++ b/templates/add_user.html
@@ -12,7 +12,7 @@
   {% if directory_users%}
     <form id="users-add-form" method="post" action="{{ BASE_URL }}/user/add">
       <p>Select Users to Add.</p>
-      <table>
+      <table class="padding-between-columns">
         <tr>
           <th>-</th>
           <th>Name</th>

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -14,9 +14,9 @@
         </paper-button></a>
       <br />
   </div>
-  <paper-card heading="Previous Notifications">
+  <paper-card heading="Previous Notifications" id="notifications-card">
     <div class="card-content">
-      <table>
+      <table class="padding-between-columns">
         <tr>
           <th>Number</th>
           <th>State</th>

--- a/templates/proxy_server.html
+++ b/templates/proxy_server.html
@@ -16,7 +16,9 @@
       <div class="card-content">
         <p>{{ proxy_server.ip_address }}, {{ proxy_server.fingerprint }}</p>
         <paper-button onclick="toggleCollapse('collapse-{{loop.index}}')">Show/hide SSH Key</paper-button>
-        <iron-collapse id="collapse-{{loop.index}}"><div>{{ proxy_server.ssh_private_key }}</div></iron-collapse>
+        <iron-collapse id="collapse-{{loop.index}}"><div>
+          <textarea rows="20" cols="80">{{ proxy_server.ssh_private_key }}
+          </textarea></div></iron-collapse>
       </div>
       <div class="card-actions">
         <a href="{{ BASE_URL }}/proxyserver/edit?id={{ proxy_server.key.id() }}">

--- a/templates/setup_client.html
+++ b/templates/setup_client.html
@@ -5,7 +5,7 @@
   <link rel="import" href="/bower_components/paper-input/paper-input.html" />
 {% endblock %}
 {% block body %}
-  <form id="setup-form" method="post" action="{{ BASE_URL }}/setup/oauthclient">
+  <form id="setup-form" method="post" action="{{ BASE_URL }}/setup">
     <paper-input label="Client ID" type="text" name="client_id" value="{{ client_id }}" required></paper-input>
     <paper-input label="Client Secret" type="text" name="client_secret" value="{{ client_secret }}" required></paper-input>
     <p>Please input the text from the content field of a meta tag supplied by Google for domain verification. You can find this data by going to Search Console and clicking on your project, such https://your-project-name-here.appspot.com/. Inside your project, click the gear logo and go to Verification Details. From here, you need to find the HTML tag method of verification. Inside the meta tag is a field called content. Copy everything between the double-quotes for content and paste it into this box. Once you've submitted this form, you can go back to your project in appspot and click Verify to complete verification.</p>

--- a/templates/user_details.html
+++ b/templates/user_details.html
@@ -12,15 +12,17 @@
         <p>{{ user.name }}, {{ user.email }}</p>
         <p>Access Status: <b>
           {% if user.is_key_revoked %}
-            Revoked
+            Disabled
           {% else %}
             Enabled
           {% endif %}
         </b></p>
         <paper-button onclick="toggleCollapse('collapse-pri')">Show/hide SSH Private Key</paper-button>
-        <iron-collapse id="collapse-pri"><div>{{ user.private_key }}</div></iron-collapse><br>
+        <iron-collapse id="collapse-pri"><div><textarea rows="20" cols="80">
+          {{ user.private_key }}</textarea></div></iron-collapse><br>
         <paper-button onclick="toggleCollapse('collapse-pub')">Show/hide SSH Public Key</paper-button>
-        <iron-collapse id="collapse-pub"><div>{{ user.public_key }}</div></iron-collapse>
+        <iron-collapse id="collapse-pub"><div><textarea rows="20" cols="80">
+          {{ user.public_key }}</textarea></div></iron-collapse>
       </div>
       <div class="card-actions">
         <a href="{{ BASE_URL }}/user/delete?key={{ key }}">
@@ -33,7 +35,12 @@
           <paper-button raised class="anchor-button">Rotate Key Pair
         </paper-button></a>
         <a href="{{ BASE_URL }}/user/toggleRevoked?key={{ key }}">
-          <paper-button raised class="anchor-button">Revoke/Unrevoke Access
+          <paper-button raised class="anchor-button">
+          {% if user.is_key_revoked %}
+            Enable
+          {% else %}
+            Disable
+          {% endif %} Access
         </paper-button></a>
       </div>
     </paper-card>

--- a/tests/ui/base_driver.py
+++ b/tests/ui/base_driver.py
@@ -7,4 +7,5 @@ class BaseDriver(object):
   # pylint: disable=too-few-public-methods
 
   def __init__(self, driver):
+    """Create the base driver object."""
     self.driver = driver

--- a/tests/ui/base_test.py
+++ b/tests/ui/base_test.py
@@ -7,5 +7,6 @@ class BaseTest(unittest.TestCase):
   """Base test class to inherit from."""
 
   def __init__(self, methodName='runTest', args=None):
+    """Create the base test object for others to inherit."""
     super(BaseTest, self).__init__(methodName)
     self.args = args

--- a/tests/ui/landing_page.py
+++ b/tests/ui/landing_page.py
@@ -12,10 +12,13 @@ class LandingPage(BaseDriver):
   INSTRUCTION = (By.TAG_NAME, 'h4')
 
   def GetTitle(self):
+    """Get the title element on the landing page."""
     return self.driver.find_element(*self.TITLE)
 
   def GetInstruction(self):
+    """Get the instructions element on the landing page."""
     return self.driver.find_element(*self.INSTRUCTION)
 
   def GetSidebar(self):
+    """Get the sidebar element on the landing page."""
     return self.driver.find_element(*Sidebar.SIDEBAR)

--- a/tests/ui/sidebar.py
+++ b/tests/ui/sidebar.py
@@ -19,4 +19,5 @@ class Sidebar(BaseDriver):
 
 
   def GetLink(self, link_locator):
+    """Get an element in the sidebar based on the link locator given."""
     return self.driver.find_element(*link_locator)

--- a/tests/ui/user_page.py
+++ b/tests/ui/user_page.py
@@ -15,8 +15,10 @@ class UserPage(BaseDriver):
 
 
   def GetAddUserLink(self):
+    """Get the add user element on the user page."""
     return WebDriverWait(self.driver, 10).until(
         EC.visibility_of_element_located(((self.ADD_USERS_LINK))))
 
   def GetSidebar(self):
+    """Get the sidebar element on the user page."""
     return self.driver.find_element(*Sidebar.SIDEBAR)

--- a/user_test.py
+++ b/user_test.py
@@ -60,22 +60,25 @@ class UserTest(unittest.TestCase):
   # pylint: disable=too-many-public-methods
 
   def setUp(self):
+    """Setup test app on which to call handlers."""
     self.testapp = webtest.TestApp(user.APP)
 
   @patch('user._RenderLandingTemplate')
   def testLandingPageHandler(self, mock_landing_template):
+    """Test get on the landing handler renders the home page."""
     self.testapp.get('/')
     mock_landing_template.assert_called_once_with()
 
   @patch('user._RenderUserListTemplate')
   def testListUsersHandler(self, mock_user_template):
+    """Test the list handler displays users from the datastore."""
     self.testapp.get('/user')
     mock_user_template.assert_called_once_with()
 
   @patch('user.User.DeleteByKey')
   @patch('user._RenderUserListTemplate')
-  def testDeleteUserHandler(self, mock_user_template,
-                            mock_delete_user):
+  def testDeleteUserHandler(self, mock_user_template, mock_delete_user):
+    """Test the delete handler calls to delete the user from the datastore."""
     self.testapp.get('/user/delete?key=%s' % FAKE_DS_KEY)
     mock_delete_user.assert_called_once_with(FAKE_DS_KEY)
     mock_user_template.assert_called_once_with()
@@ -85,6 +88,7 @@ class UserTest(unittest.TestCase):
   @patch('user._RenderUserDetailsTemplate')
   def testGetInviteCodeHandler(self, mock_user_template, mock_make_invite_code,
                                mock_get_user):
+    """Test the invite code handler generates an invite code for the user."""
     mock_get_user.return_value = FAKE_USER
     fake_invite_code = 'base64EncodedBlob'
     mock_make_invite_code.return_value = fake_invite_code
@@ -100,6 +104,7 @@ class UserTest(unittest.TestCase):
   @patch('user.User.UpdateKeyPair')
   def testGetNewKeyPairHandler(self, mock_update, mock_get_by_key,
                                mock_render_details):
+    """Test the key pair handler calls to set a new key pair for the user."""
     mock_get_by_key.return_value = FAKE_USER
 
     self.testapp.get('/user/getNewKeyPair?key=%s' % FAKE_DS_KEY)
@@ -117,6 +122,7 @@ class UserTest(unittest.TestCase):
   def testAddUsersGetHandlerNoParam(self, mock_ds, mock_get_users,
                                     mock_get_by_key, mock_get_user,
                                     mock_watch_users, mock_render):
+    """Test the add users get handler displays no users on initial get."""
     # pylint: disable=too-many-arguments
     mock_ds.return_value = None
     self.testapp.get('/user/add')
@@ -137,6 +143,7 @@ class UserTest(unittest.TestCase):
   def testAddUsersGetHandlerWithGroup(self, mock_ds, mock_get_users,
                                       mock_get_by_key, mock_get_user,
                                       mock_watch_users, mock_render):
+    """Test the add users get handler displays users from a given group."""
     # pylint: disable=too-many-arguments
     mock_ds.return_value = None
     # Email address could refer to group or user
@@ -163,6 +170,7 @@ class UserTest(unittest.TestCase):
   def testAddUsersGetHandlerWithUser(self, mock_ds, mock_get_users,
                                      mock_get_by_key, mock_get_user,
                                      mock_watch_users, mock_render):
+    """Test the add users get handler displays a given user as requested."""
     # pylint: disable=too-many-arguments
     mock_ds.return_value = None
     # Email address could refer to group or user
@@ -189,6 +197,7 @@ class UserTest(unittest.TestCase):
   def testAddUsersGetHandlerWithAll(self, mock_ds, mock_get_users,
                                     mock_get_by_key, mock_get_user,
                                     mock_watch_users, mock_render):
+    """Test the add users get handler displays all users in a domain."""
     # pylint: disable=too-many-arguments
     mock_ds.return_value = None
     mock_get_users.return_value = FAKE_USER_ARRAY
@@ -213,6 +222,7 @@ class UserTest(unittest.TestCase):
   def testAddUsersGetHandlerWithError(self, mock_ds, mock_get_users,
                                       mock_get_by_key, mock_get_user,
                                       mock_watch_users, mock_render):
+    """Test the add users get handler fails gracefully."""
     # pylint: disable=too-many-arguments
     fake_status = '404'
     fake_response = MagicMock(status=fake_status)
@@ -231,6 +241,7 @@ class UserTest(unittest.TestCase):
 
   @patch('user.User.InsertUsers')
   def testAddUsersPostHandler(self, mock_insert):
+    """Test the add users post handler calls to insert the specified users."""
     user_1 = {}
     user_1['primaryEmail'] = FAKE_EMAIL_1
     user_1['name'] = {}
@@ -254,6 +265,7 @@ class UserTest(unittest.TestCase):
   @patch('user.User.ToggleKeyRevoked')
   def testToggleKeyRevokedHandler(self, mock_toggle_key_revoked,
                                   mock_get_by_key, mock_render_details):
+    """Test the toggle revoked handler toggles a user's status in datastore."""
     mock_get_by_key.return_value = FAKE_USER
 
     self.testapp.get('/user/toggleRevoked?key=%s' % FAKE_DS_KEY)
@@ -265,6 +277,7 @@ class UserTest(unittest.TestCase):
   @patch('user._RenderUserDetailsTemplate')
   @patch('user.User.GetByKey')
   def testGetUserDetailsHandler(self, mock_get_by_key, mock_render_details):
+    """Test the user details handler calls to render a user's information."""
     mock_get_by_key.return_value = FAKE_USER
 
     self.testapp.get('/user/details?key=%s' % FAKE_DS_KEY)
@@ -275,6 +288,10 @@ class UserTest(unittest.TestCase):
   @patch('user._GenerateUserPayload')
   @patch('user.User.GetAll')
   def testRenderUserListTemplate(self, mock_get_all, mock_generate):
+    """Test the user list is rendered as in the html."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     fake_users = [FAKE_USER]
     mock_get_all.return_value = fake_users
     fake_dictionary = {}
@@ -294,6 +311,10 @@ class UserTest(unittest.TestCase):
 
   @patch('datastore.DomainVerification.GetOrInsertDefault')
   def testRenderLandingTemplate(self, mock_domain_verif):
+    """Test the basic landing page is rendered as in the html."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     fake_content = 'foobarbaz'
     fake_domain_verif = MagicMock(content=fake_content)
     mock_domain_verif.return_value = fake_domain_verif
@@ -304,6 +325,10 @@ class UserTest(unittest.TestCase):
     self.assertTrue(fake_content in landing_template)
 
   def testRenderAddUsersWithNoUsers(self):
+    """Test the user add form is rendered properly without users."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     add_users_template = user._RenderAddUsersTemplate([])
     no_user_string = 'No users found. Try another query below.'
     self.assertTrue(no_user_string in add_users_template)
@@ -311,12 +336,20 @@ class UserTest(unittest.TestCase):
     self.assertTrue('An error occurred while' not in add_users_template)
 
   def testRenderAddUsersWithUsers(self):
+    """Test the user add form is rendered properly with users."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     add_users_template = user._RenderAddUsersTemplate(FAKE_USER_ARRAY)
     self.assertTrue('Add Selected Users' in add_users_template)
     self.assertTrue('xsrf' in add_users_template)
     self.assertTrue('An error occurred while' not in add_users_template)
 
   def testRenderAddUsersWithError(self):
+    """Test the user add form is rendered properly with an error."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     fake_error = 'foo bar happened causing baz'
     add_users_template = user._RenderAddUsersTemplate([], fake_error)
     self.assertTrue('An error occurred while' in add_users_template)
@@ -324,6 +357,10 @@ class UserTest(unittest.TestCase):
 
   @patch.object(user.User, 'key')
   def testRenderUserDetailTemplate(self, mock_url_key):
+    """Test the user detail page is rendered with a user's properties."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     mock_url_key.urlsafe.return_value = FAKE_DS_KEY
 
     user_details_template = user._RenderUserDetailsTemplate(FAKE_USER)
@@ -338,6 +375,10 @@ class UserTest(unittest.TestCase):
 
   @patch.object(user.User, 'key')
   def testRenderUserDetailInviteCode(self, mock_url_key):
+    """Test the user detail page is rendered with an invite code."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     fake_invite_code = 'foo bar baz in base64 blob'
     mock_url_key.urlsafe.return_value = FAKE_DS_KEY
 
@@ -355,6 +396,10 @@ class UserTest(unittest.TestCase):
 
   @patch.object(user.User, 'key')
   def testGenerateUserPayload(self, mock_url_key):
+    """Test that a user payload does not include the user's keys."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     mock_url_key.urlsafe.return_value = FAKE_DS_KEY
     fake_users = [FAKE_USER]
 
@@ -369,6 +414,10 @@ class UserTest(unittest.TestCase):
 
   @patch('user._GetInviteCodeIp')
   def testMakeInviteCode(self, mock_get_ip):
+    """Test that making an invite code follows the proper format."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     fake_ip = '0.0.0.0'
     mock_get_ip.return_value = fake_ip
 
@@ -388,6 +437,10 @@ class UserTest(unittest.TestCase):
 
   @patch('user.ProxyServer.GetAll')
   def testGetInviteCodeIp(self, mock_get_all_proxies):
+    """Test that an invite code IP belongs to some proxy server."""
+    # Disabling the protected access check here intentionally so we can test a
+    # private method.
+    # pylint: disable=protected-access
     fake_ip_1 = '0.0.0.0'
     fake_proxy_1 = MagicMock(ip_address=fake_ip_1)
     fake_ip_2 = '1.2.3.4'


### PR DESCRIPTION
This just cleans up a lot of random things. On the UI side, it adds padding between cells in the html, makes our forms have a bounded size so they don't go off the page, and renders users'/servers' keys in a textarea so they fit properly within a card. On the code side, it adds an insane amount of docstrings so that our tests are now covered and disables the check for calling a protected method in the tests where we intentionally call protected methods.

Functionally, this doesn't really change anything, but it should bring us to a nice level of overall repo health before we leave for vacation. My hope is that fixing this now will pay dividends later since no one will likely touch the code for half a month.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server/59)
<!-- Reviewable:end -->
